### PR TITLE
Fix examples-full loop in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ examples: clean
 	done
 
 examples-full: clean
-	@for i in @for i in examples/*/*.py;do \
+	@for i in examples/*/*.py; do \
 		echo "-----------------------------------------------"; \
 		echo $$i; \
 		echo "-----------------------------------------------"; \


### PR DESCRIPTION
## Summary
- fix the `examples-full` recipe to use a single `for` loop over all example scripts

## Testing
- make -n examples-full

------
https://chatgpt.com/codex/tasks/task_e_68caf2b7e1c88328ae8a0a30f45d667a