### PR TITLE
Adjust Makefile all target dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # simple makefile to simplify repetetive build env management tasks under posix
 CTAGS ?= ctags
 
-all: clean inplace test-nongui
+all: clean inplace test
 
 inplace:
 	@python -m pip install -e .


### PR DESCRIPTION
## Summary
- update the Makefile `all` target to depend on `clean`, `inplace`, and `test` so it only references existing targets

## Testing
- make all

------
https://chatgpt.com/codex/tasks/task_e_68cb0038530c83289e01a4ff3833fde8