### PR TITLE
Fix examples-full loop syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,13 +56,7 @@ examples: clean
 	done
 
 examples-full: clean
-	@for i in examples/*/*.py; do \
-		echo "-----------------------------------------------"; \
-		echo $$i; \
-		echo "-----------------------------------------------"; \
-		python $$i --visbrain-show=False; \
-		echo "\n"; \
-	done
+	@for i in examples/*/*.py; do echo "-----------------------------------------------"; echo $$i; echo "-----------------------------------------------"; python $$i --visbrain-show=False; echo "\n"; done
 
 pypi: build_dist
 	@twine upload --verbose dist/*


### PR DESCRIPTION
## Summary
- collapse the `examples-full` recipe into a single shell loop so it iterates over every example script while preserving the existing echo output and CLI flags

## Testing
- make examples-full -n

------
https://chatgpt.com/codex/tasks/task_e_68cb003e111c8328a47ded50bd3a387d