### PR TITLE
Align modernization plan on PySide6 baseline

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Visbrain
 .. figure::  https://github.com/EtienneCmb/visbrain/blob/master/docs/_static/ico/visbrain.png
     :align:  center
 
-**Visbrain** is an open-source python 3 package dedicated to brain signals visualization. It is based on top of `VisPy <http://vispy.org/>`_ and PyQt and is distributed under the 3-Clause BSD license. We also provide an on line `documentation <http://visbrain.org>`_, `examples and datasets <http://visbrain.org/auto_examples/>`_ and can also be downloaded from `PyPi <https://pypi.python.org/pypi/visbrain/>`_.
+**Visbrain** is an open-source python 3 package dedicated to brain signals visualization. It is based on top of `VisPy <http://vispy.org/>`_ and the Qt 6 stack exposed through PySide6 and is distributed under the 3-Clause BSD license. We also provide an on line `documentation <http://visbrain.org>`_, `examples and datasets <http://visbrain.org/auto_examples/>`_ and can also be downloaded from `PyPi <https://pypi.python.org/pypi/visbrain/>`_.
 
 Modernization roadmap
 ---------------------
@@ -69,7 +69,7 @@ Visbrain requires :
 * SciPy >= 1.9
 * VisPy >= 0.12
 * Matplotlib >= 3.6
-* PyQt5 >= 5.15
+* PySide6 >= 6.7 (installs ``shiboken6``)
 * Pillow >= 9.5
 * PyOpenGL >= 3.1.6
 

--- a/conftest.py
+++ b/conftest.py
@@ -80,7 +80,9 @@ def _is_under(path: Path, parents: Iterable[Path]) -> bool:
     return False
 
 
-def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
     """Mark tests under GUI-specific paths with the ``gui`` marker."""
     for item in items:
         item_path = Path(str(item.fspath)).resolve()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,7 +42,7 @@
     <h1 class="display-3">Visbrain documentation <img alt="_static/ico/visbrain.png" src="_static/ico/visbrain.png" width="200" height="200" align="right"></h1>
     <p class="lead">A multi-purpose GPU-accelerated open-source suite for brain data visualization.</p>
     <hr class="my-4">
-    <p>Visbrain is an open-source <a href="https://www.python.org/">Python 3</a> package dedicated to brain signals visualization. It is based on top of <a href="http://vispy.org/">VisPy</a> and <a href="https://riverbankcomputing.com/software/pyqt/intro">PyQt</a> and is distributed under the 3-Clause BSD license.</p>
+    <p>Visbrain is an open-source <a href="https://www.python.org/">Python 3</a> package dedicated to brain signals visualization. It is based on top of <a href="http://vispy.org/">VisPy</a> and <a href="https://doc.qt.io/qtforpython/">PySide6</a> and is distributed under the 3-Clause BSD license.</p>
     <p class="lead" align="center">
       <a class="btn btn-primary btn-lg" href="documentation.html" role="button" style="color:white">Learn more</a>
       <a class="btn btn-success btn-lg" href="introduction.html#install-visbrain" role="button" style="color:white">Install</a>

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -52,7 +52,7 @@ Dependencies
 * NumPy (>= 1.23) and SciPy (>= 1.9)
 * Matplotlib (>= 3.6)
 * VisPy (>= 0.12)
-* PyQt5 (>= 5.15)
+* PySide6 (>= 6.7) and ``shiboken6``
 * PyOpenGL (>= 3.1.6)
 * Pillow (>= 9.5)
 

--- a/docs/modernization/phase-0.rst
+++ b/docs/modernization/phase-0.rst
@@ -23,7 +23,9 @@ remaining realistic for the team to test:
   x86_64), and Ubuntu 22.04 LTS or newer.
 * **Qt binding**: PySide6 is adopted as the official GUI backend. It ships
   wheels for all target platforms, has an LGPL-friendly license, and maps
-  closely onto Qt 6 API expectations.
+  closely onto Qt 6 API expectations. Shipping with the Qt 6 stack keeps the
+  modernization roadmap focused on the end-state platform rather than
+  maintaining compatibility shims for PyQt5.
 
 These targets will guide dependency minimums, CI matrices, and documentation
 updates in later phases.
@@ -54,5 +56,5 @@ Next steps
 * Track early compatibility issues with PySide6 and Qt 6 APIs while preparing
 * Document environment quirks as they surface so future contributors have
   up-to-date guidance.
-* Begin auditing modules that rely on deprecated PyQt5-only behavior in
-  preparation for Phase 2 refactors.
+* Begin auditing modules that rely on PyQt5-only behavior so they can be
+  replaced with PySide6-compatible patterns ahead of Phase 2 refactors.

--- a/docs/modernization/phase-1.rst
+++ b/docs/modernization/phase-1.rst
@@ -9,7 +9,7 @@ current Python toolchains. The guiding principles are:
 
 * publish metadata through ``pyproject.toml`` rather than ``setup.py``;
 * raise dependency floors to versions that support Python 3.9+; and
-* keep the legacy PyQt5 runtime working until the Qt 6 port lands.
+* codify PySide6 as the supported Qt binding across packaging inputs.
 
 Key changes
 -----------
@@ -20,10 +20,10 @@ past ``setup.py`` options, and declares a modern Python range. ``setup.py`` is
 retained as a thin shim so existing workflows that call ``python setup.py``
 continue to function.
 
-The pinned requirement files were refreshed to align with the metadata. PyQt5
-5.15.x remains in place for runtime compatibility, while the optional extras are
-ready for the eventual Qt 6 migration. ``MANIFEST.in`` will continue to ship the
-resource files consumed at runtime.
+The pinned requirement files were refreshed to align with the metadata. PySide6
+and its companion ``shiboken6`` package anchor the runtime stack, while the
+optional extras mirror the ``pyproject.toml`` extras. ``MANIFEST.in`` will
+continue to ship the resource files consumed at runtime.
 
 Developer workflow
 ------------------
@@ -45,7 +45,7 @@ Next steps
 
 * Convert continuous integration workflows to rely on ``pyproject.toml`` so
   future jobs no longer invoke ``setup.py`` directly.
-* Begin extracting Qt-bound logic into dedicated adapters so Phase 2 can add a
-  PySide6-backed implementation without breaking PyQt5 users.
+* Begin extracting Qt-bound logic into dedicated adapters so Phase 2 can
+  standardize on PySide6-friendly abstractions.
 * Audit package data requirements and move any implicit resources into explicit
   ``tool.setuptools.package-data`` declarations.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,8 @@ dependencies = [
     "scipy>=1.9",
     "vispy>=0.12",
     "matplotlib>=3.6",
-    "PyQt5>=5.15",
+    "PySide6>=6.7",
+    "shiboken6>=6.7",
     "pillow>=9.5",
     "PyOpenGL>=3.1.6",
 ]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,12 +1,10 @@
 # Runtime dependencies validated for the Phase 1 packaging migration.
-# The Qt stack remains on PyQt5 until the GUI layer is ported to Qt 6 APIs.
+# The Qt stack now targets PySide6 to match the modernization baseline.
 
 numpy==1.26.4
 scipy==1.11.4
 matplotlib==3.8.4
 vispy==0.13.0
-PyQt5==5.15.10
-=======
 PySide6==6.7.1
 shiboken6==6.7.1
 pillow==10.3.0


### PR DESCRIPTION
## Summary
- align the modernization roadmap narrative around PySide6 as the supported Qt binding
- switch packaging metadata and pinned requirements to depend on PySide6/shiboken6 instead of PyQt5
- refresh high-level documentation to describe the PySide6 baseline

## Testing
- make flake
- pytest *(fails: ImportError: libGL.so.1 missing in container)*
- python -m build

------
https://chatgpt.com/codex/tasks/task_e_68cb092e1fe08328bbc0eb7f700d80b4