### PR TITLE
Refactor application configuration for headless imports

### DIFF
--- a/visbrain/_pyqt_module.py
+++ b/visbrain/_pyqt_module.py
@@ -24,7 +24,7 @@ except ImportError:  # pragma: no cover - shiboken missing
     shiboken6 = None
 
 from .utils import set_widget_size, set_log_level
-from .config import PROFILER, CONFIG
+from .config import CONFIG, PROFILER, get_qt_app, get_vispy_app
 from .io import path_to_tmp, clean_tmp, path_to_visbrain_data
 
 logger = logging.getLogger('visbrain')
@@ -114,7 +114,7 @@ class _PyQtModule(object):
         """Display the graphical user interface."""
         # Fixed size for the settings panel :
         if hasattr(self, 'q_widget'):
-            set_widget_size(CONFIG['PYQT_APP'], self.q_widget, 23)
+            set_widget_size(get_qt_app(), self.q_widget, 23)
             self.q_widget.setVisible(self._show_settings)
         # Force the quick settings tab to be on the first tab :
         if hasattr(self, 'QuickSettings'):
@@ -150,11 +150,13 @@ class _PyQtModule(object):
         # If PyQt GUI :
         if CONFIG['SHOW_PYQT_APP']:
             self.showMaximized()
-            CONFIG['VISPY_APP'].run()
+            get_vispy_app().run()
         # Finally clean the tmp folder :
         self._clean_tmp_folder()
 
     def closeEvent(self, event):  # noqa
         """Executed method when the GUI closed."""
-        CONFIG['PYQT_APP'].quit()
+        app = get_qt_app(create=False)
+        if app is not None:
+            app.quit()
         logger.debug("App closed.")

--- a/visbrain/objects/scene_obj.py
+++ b/visbrain/objects/scene_obj.py
@@ -9,7 +9,7 @@ from ..io import write_fig_canvas, mpl_preview, dialog_save
 from ..qt import QtWidgets
 from ..utils import color2vb, set_log_level, rotate_turntable, FixedCam
 from ..visuals import CbarVisual
-from ..config import CONFIG, PROFILER
+from ..config import CONFIG, PROFILER, get_vispy_app
 
 logger = logging.getLogger('visbrain')
 
@@ -692,4 +692,4 @@ class SceneObj(object):
                 logger.profiler(" ")
                 PROFILER.finish()
             if sys.flags.interactive != 1 and CONFIG['SHOW_PYQT_APP']:
-                CONFIG['VISPY_APP'].run()
+                get_vispy_app().run()

--- a/visbrain/objects/visbrain_obj.py
+++ b/visbrain/objects/visbrain_obj.py
@@ -19,7 +19,7 @@ from ..io import (
 )
 from ..qt import QtWidgets
 from ..utils import color2vb, set_log_level, merge_cameras
-from ..config import CONFIG
+from ..config import CONFIG, get_vispy_app
 from ..visuals import CbarBase
 
 logger = logging.getLogger('visbrain')
@@ -240,7 +240,7 @@ class VisbrainObject(_VisbrainObj):
                 vispy.scene.visuals.XYZAxis(parent=canvas.wc.scene)
             # view.camera = camera
             if (sys.flags.interactive != 1) and show:
-                CONFIG['VISPY_APP'].run()
+                get_vispy_app().run()
             # Reset orignial parent :
             self._node.parent = parent_bck
 
@@ -268,7 +268,7 @@ class VisbrainObject(_VisbrainObj):
         def on_timer(*args, **kwargs):  # noqa
             if hasattr(self, 'camera'):
                 self.camera.azimuth += step  # noqa
-        kw = dict(connect=on_timer, app=CONFIG['VISPY_APP'],
+        kw = dict(connect=on_timer, app=get_vispy_app(),
                   interval=interval, iterations=iterations)
         self._app_timer = Timer(**kw)
         self._app_timer.start()

--- a/visbrain/tests/test_config_apps.py
+++ b/visbrain/tests/test_config_apps.py
@@ -1,0 +1,99 @@
+"""Headless safety checks for the application factories."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import vispy.app
+
+from visbrain import qt as qt_mod
+
+
+def test_config_import_has_no_side_effect(monkeypatch):
+    """Importing :mod:`visbrain.config` must not create GUI applications."""
+
+    class DummyQApplication:
+        created = 0
+        _instance: DummyQApplication | None = None
+
+        @staticmethod
+        def instance():
+            return DummyQApplication._instance
+
+        def __init__(self, *args, **kwargs):
+            DummyQApplication.created += 1
+            DummyQApplication._instance = self
+
+    class DummyVispyApplication:
+        created = 0
+
+        def __init__(self, *args, **kwargs):
+            DummyVispyApplication.created += 1
+
+    with monkeypatch.context() as m:
+        m.setattr(qt_mod.QtWidgets, "QApplication", DummyQApplication)
+        m.setattr(vispy.app.application, "Application", DummyVispyApplication)
+        sys.modules.pop("visbrain.config", None)
+        cfg = importlib.import_module("visbrain.config")
+
+        assert DummyQApplication.created == 0
+        assert DummyVispyApplication.created == 0
+        assert cfg.CONFIG["PYQT_APP"] is None
+        assert cfg.CONFIG["VISPY_APP"] is None
+
+    sys.modules.pop("visbrain.config", None)
+    importlib.import_module("visbrain.config")
+
+
+def test_app_factories_create_on_demand(monkeypatch):
+    """Application factories should lazily instantiate applications."""
+
+    sys.modules.pop("visbrain.config", None)
+    cfg = importlib.import_module("visbrain.config")
+
+    class DummyQApplication:
+        created = 0
+        _instance: DummyQApplication | None = None
+
+        @staticmethod
+        def instance():
+            return DummyQApplication._instance
+
+        def __init__(self, *args, **kwargs):
+            DummyQApplication.created += 1
+            DummyQApplication._instance = self
+
+    with monkeypatch.context() as m:
+        m.setattr(cfg, "_QT_APP", None)
+        m.setitem(cfg.CONFIG, "PYQT_APP", None)
+        m.setattr(cfg.QtWidgets, "QApplication", DummyQApplication)
+
+        assert cfg.get_qt_app(create=False) is None
+        app = cfg.get_qt_app()
+        assert isinstance(app, DummyQApplication)
+        assert DummyQApplication.created == 1
+        assert cfg.CONFIG["PYQT_APP"] is app
+        assert cfg.get_qt_app() is app
+
+    class DummyVispyApplication:
+        created = 0
+
+        def __init__(self, backend=None):
+            DummyVispyApplication.created += 1
+            self.backend = backend
+
+    with monkeypatch.context() as m:
+        m.setattr(cfg, "_VISPY_APP", None)
+        m.setitem(cfg.CONFIG, "VISPY_APP", None)
+        m.setattr(cfg.visapp.application, "Application", DummyVispyApplication)
+
+        app = cfg.get_vispy_app()
+        assert isinstance(app, DummyVispyApplication)
+        assert DummyVispyApplication.created == 1
+        assert app.backend == cfg.CONFIG["VISPY_BACKEND"]
+        assert cfg.CONFIG["VISPY_APP"] is app
+        assert cfg.get_vispy_app() is app
+
+    sys.modules.pop("visbrain.config", None)
+    importlib.import_module("visbrain.config")


### PR DESCRIPTION
## Summary
- lazily initialize Qt and VisPy applications via new `get_qt_app`/`get_vispy_app` helpers in `visbrain.config`
- update GUI modules to request application instances on demand instead of relying on eager globals
- add headless regression tests ensuring importing `visbrain.config` has no side effects and factories create apps when needed

## Testing
- `make flake`
- `pytest -m "not gui"`
- `pytest` *(fails: GUI signal test aborts the interpreter under headless execution)*

------
https://chatgpt.com/codex/tasks/task_e_68cba8825428832893bda02919cb0403