### PR TITLE
Safely parse visbrain-show flag

### DIFF
--- a/visbrain/config.py
+++ b/visbrain/config.py
@@ -35,6 +35,32 @@ CONFIG['PYQT_APP'] = None
 CONFIG['VISPY_APP'] = None
 
 
+def _parse_bool_flag(value: str) -> bool:
+    """Return a boolean from a CLI flag value.
+
+    Accepted truthy values are ``'1'``, ``'true'``, ``'yes'``, ``'y'`` and
+    ``'on'`` (case insensitive). Accepted falsey values are the counterparts
+    ``'0'``, ``'false'``, ``'no'``, ``'n'`` and ``'off'``.
+
+    Parameters
+    ----------
+    value : str
+        The string representation of the desired boolean.
+
+    Raises
+    ------
+    ValueError
+        If *value* does not match any of the accepted representations.
+    """
+
+    normalized = value.strip().lower()
+    if normalized in {'1', 'true', 'yes', 'y', 'on'}:
+        return True
+    if normalized in {'0', 'false', 'no', 'n', 'off'}:
+        return False
+    raise ValueError(f"Unsupported boolean value: {value!r}")
+
+
 def get_qt_app(create: bool = True) -> Optional[QtWidgets.QApplication]:
     """Return the active :class:`~QtWidgets.QApplication` instance.
 
@@ -133,8 +159,16 @@ def init_config(argv):
             if o == '--visbrain-log':
                 set_log_level(a)
             if o == '--visbrain-show':
-                CONFIG['SHOW_PYQT_APP'] = eval(a)
-                logger.debug("Show PyQt app : %r" % CONFIG['SHOW_PYQT_APP'])
+                try:
+                    CONFIG['SHOW_PYQT_APP'] = _parse_bool_flag(a)
+                except ValueError:
+                    logger.error(
+                        f"Invalid value for --visbrain-show: {a}"
+                    )
+                else:
+                    logger.debug(
+                        "Show PyQt app : %r", CONFIG['SHOW_PYQT_APP']
+                    )
             if o == '--visbrain-search':
                 set_log_level(match=a)
 

--- a/visbrain/tests/test_config_cli.py
+++ b/visbrain/tests/test_config_cli.py
@@ -1,0 +1,49 @@
+"""Tests for :mod:`visbrain.config` command line parsing."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import sys
+
+
+def _reload_config():
+    sys.modules.pop("visbrain.config", None)
+    return importlib.import_module("visbrain.config")
+
+
+def test_init_config_accepts_boolean_flag(monkeypatch):
+    """A valid ``--visbrain-show`` argument toggles the GUI flag."""
+
+    cfg = _reload_config()
+    cfg.CONFIG["SHOW_PYQT_APP"] = True
+
+    with monkeypatch.context() as m:
+        m.setattr(sys, "argv", [
+            "visbrain",
+            "--visbrain-show=False",
+        ])
+        cfg.init_config(["--visbrain-show=False"])
+
+    assert cfg.CONFIG["SHOW_PYQT_APP"] is False
+
+
+def test_init_config_rejects_invalid_boolean(monkeypatch, caplog):
+    """Invalid boolean arguments fall back to the default and log errors."""
+
+    cfg = _reload_config()
+    cfg.CONFIG["SHOW_PYQT_APP"] = True
+
+    with monkeypatch.context() as m:
+        m.setattr(sys, "argv", [
+            "visbrain",
+            "--visbrain-show=__import__('os').system('echo unsafe')",
+        ])
+        caplog.set_level(logging.ERROR, logger="visbrain")
+        cfg.init_config(["--visbrain-show=__import__('os').system('echo unsafe')"])
+
+    assert cfg.CONFIG["SHOW_PYQT_APP"] is True
+    assert any(
+        "Invalid value for --visbrain-show" in record.message
+        for record in caplog.records
+    )


### PR DESCRIPTION
## Summary
- replace the eval-based --visbrain-show handling with an explicit string-to-bool parser that logs invalid values
- add regression tests covering valid and invalid --visbrain-show arguments so the flag can no longer execute arbitrary code

## Testing
- make flake
- QT_QPA_PLATFORM=offscreen pytest *(fails: visbrain.gui.signal imports abort the process in this headless environment)*
- pytest visbrain/tests/test_config_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68cbabee8aac83288d9ad5a324bbf027