### PR TITLE
Refactor runtime configuration API

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -23,10 +23,11 @@ from _pytest.mark.expression import Expression
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 try:
-    from visbrain.config import CONFIG
+    from visbrain.config import get_config
 except Exception:  # pragma: no cover - defensive in CI without GUI libs
     CONFIG = None
 else:
+    CONFIG = get_config()
     # Prevent Visbrain from attempting to display PyQt applications during
     # tests when the GUI stack is available.
     CONFIG.show_pyqt_app = False

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ from sphinx_gallery.sorting import FileNameSortKey, ExplicitOrder
 from numpydoc import numpydoc, docscrape
 
 import visbrain
-from visbrain.config import CONFIG
+from visbrain.config import get_config
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -443,4 +443,4 @@ def linkcode_resolve(domain, info):
        fn, linespec)
 
 # Render using Matplotlib :
-CONFIG.mpl_render = True
+get_config().mpl_render = True

--- a/docs/modernization/phase-2.rst
+++ b/docs/modernization/phase-2.rst
@@ -6,32 +6,33 @@ side effects from :mod:`visbrain.config` and codifying the way GUI resources
 are created.  Earlier releases built Qt and VisPy application instances as soon
 as the module was imported, which complicated headless automation and made it
 hard to reason about global state.  The refactor introduces an explicit
-``ConfigManager`` facade that keeps track of runtime flags and lazy factories
+``VisbrainConfig`` facade that keeps track of runtime flags and lazy factories
 for GUI backends.
 
 Key changes
 -----------
 
-* ``ConfigManager`` exposes the active Qt backend, Matplotlib render flag and
+* ``VisbrainConfig`` exposes the active Qt backend, Matplotlib render flag and
   any instantiated GUI handles through attributes instead of the previous
   mutable dictionary.
 * ``ensure_qt_app()`` and ``ensure_vispy_app()`` lazily create GUI
-  applications.  Both respect the ``ConfigManager.show_pyqt_app`` flag so tests
+  applications.  Both respect the ``VisbrainConfig.show_pyqt_app`` flag so tests
   run headless by default while still allowing opt-in GUI execution via the
   ``force`` argument.
-* ``parse_cli(argv, config=...)`` replaces the import-side CLI parser.  The new
+* ``configure_from_argv(argv, config=...)`` replaces the import-side CLI parser.  The new
   function accepts an explicit argument vector and returns the updated config
   object so entry points can opt in to CLI overrides without polluting module
   import.
-* ``init_config`` remains as a thin wrapper around ``parse_cli`` for legacy
-  consumers and now emits a deprecation warning.
+* ``parse_cli`` and ``init_config`` remain as thin wrappers around
+  ``configure_from_argv`` for legacy consumers and now emit a deprecation
+  warning.
 
 Running headless
 ----------------
 
 Test runners and automation harnesses should continue to set
 ``QT_QPA_PLATFORM=offscreen`` (see :mod:`conftest`) and toggle headless mode via
-``ConfigManager.show_pyqt_app = False``.  The new helpers will return ``None``
+``get_config().show_pyqt_app = False``.  The new helpers will return ``None``
 in that configuration, so call sites must guard against ``None`` before
 touching GUI handles.  When a test genuinely needs an application instance it
 can request it with ``ensure_qt_app(force=True)`` or
@@ -41,20 +42,21 @@ CLI integration
 ---------------
 
 Entry points should no longer rely on :data:`sys.argv` being consumed during
-module import.  Instead they should call ``parse_cli(sys.argv[1:], CONFIG)``
-before bootstrapping their UI.  The parser now respects all existing flags and
+module import.  Instead they should call
+``configure_from_argv(sys.argv[1:], config=get_config())`` before bootstrapping
+their UI.  The parser now respects all existing flags and
 reports invalid ``--visbrain-show`` values without mutating the stored state.
 
 Practical examples
 ------------------
 
 * Tests that previously patched ``CONFIG['SHOW_PYQT_APP']`` now use
-  ``CONFIG.show_pyqt_app``.
+  ``get_config().show_pyqt_app``.
 * GUI code should request the Qt and VisPy handles via ``ensure_qt_app()`` and
   ``ensure_vispy_app()`` rather than touching module-level globals.  Both
   helpers are safe to call in headless environments.
 * Documentation builders can enable Matplotlib rendering explicitly by setting
-  ``CONFIG.mpl_render = True`` in ``docs/conf.py``.
+  ``get_config().mpl_render = True`` in ``docs/conf.py``.
 
 These changes make the runtime state explicit and defer heavyweight resources
 until they are genuinely needed, unlocking deterministic behaviour across both

--- a/visbrain/_pyqt_module.py
+++ b/visbrain/_pyqt_module.py
@@ -24,7 +24,7 @@ except ImportError:  # pragma: no cover - shiboken missing
     shiboken6 = None
 
 from .utils import set_widget_size, set_log_level
-from .config import CONFIG, PROFILER, ensure_qt_app, ensure_vispy_app
+from .config import PROFILER, ensure_qt_app, ensure_vispy_app, get_config
 from .io import path_to_tmp, clean_tmp, path_to_visbrain_data
 
 logger = logging.getLogger('visbrain')
@@ -149,7 +149,8 @@ class _PyQtModule(object):
             self._pyqt_title('Profiler', '')
             PROFILER.finish()
         # If PyQt GUI :
-        if CONFIG.show_pyqt_app:
+        cfg = get_config()
+        if cfg.show_pyqt_app:
             self.showMaximized()
             vispy_app = ensure_vispy_app()
             if vispy_app is not None:
@@ -159,7 +160,8 @@ class _PyQtModule(object):
 
     def closeEvent(self, event):  # noqa
         """Executed method when the GUI closed."""
-        app = CONFIG.get_qt_app(create=False)
+        cfg = get_config()
+        app = cfg.get_qt_app(create=False)
         if app is not None:
             app.quit()
         logger.debug("App closed.")

--- a/visbrain/io/write_image.py
+++ b/visbrain/io/write_image.py
@@ -9,7 +9,7 @@ import logging
 import numpy as np
 
 from ..utils.color import color2vb
-from ..config import CONFIG
+from ..config import get_config
 
 logger = logging.getLogger('visbrain')
 
@@ -407,7 +407,7 @@ def write_fig_canvas(filename, canvas, widget=None, autocrop=False,
     canvas.bgcolor = backup_bgcolor
 
     # Matplotlib render :
-    if CONFIG.mpl_render or not isinstance(filename, str):
+    if get_config().mpl_render or not isinstance(filename, str):
         return img
 
     # Remove alpha for files that are not png or tiff :

--- a/visbrain/objects/scene_obj.py
+++ b/visbrain/objects/scene_obj.py
@@ -9,7 +9,7 @@ from ..io import write_fig_canvas, mpl_preview, dialog_save
 from ..qt import QtWidgets
 from ..utils import color2vb, set_log_level, rotate_turntable, FixedCam
 from ..visuals import CbarVisual
-from ..config import CONFIG, PROFILER, ensure_vispy_app
+from ..config import PROFILER, ensure_vispy_app, get_config
 
 logger = logging.getLogger('visbrain')
 
@@ -680,7 +680,8 @@ class SceneObj(object):
             interactive figure.
         """
         self._gl_uniform_transforms()
-        if CONFIG.mpl_render:
+        cfg = get_config()
+        if cfg.mpl_render:
             mpl_preview(self.canvas, widget=self.canvas.central_widget)
         else:
             self.canvas.show(visible=True)
@@ -691,7 +692,7 @@ class SceneObj(object):
                 logger.profiler("PARENT TREE\n%s" % self._grid.describe_tree())
                 logger.profiler(" ")
                 PROFILER.finish()
-            if sys.flags.interactive != 1 and CONFIG.show_pyqt_app:
+            if sys.flags.interactive != 1 and cfg.show_pyqt_app:
                 vispy_app = ensure_vispy_app()
                 if vispy_app is not None:
                     vispy_app.run()

--- a/visbrain/objects/visbrain_obj.py
+++ b/visbrain/objects/visbrain_obj.py
@@ -19,7 +19,7 @@ from ..io import (
 )
 from ..qt import QtWidgets
 from ..utils import color2vb, set_log_level, merge_cameras
-from ..config import CONFIG, ensure_vispy_app
+from ..config import ensure_vispy_app, get_config
 from ..visuals import CbarBase
 
 logger = logging.getLogger('visbrain')
@@ -237,7 +237,8 @@ class VisbrainObject(_VisbrainObj):
         kwargs : dict | {}
             Optional arguments are passed to the VisbrainCanvas class.
         """
-        if CONFIG.mpl_render or mpl:
+        cfg = get_config()
+        if cfg.mpl_render or mpl:
             canvas = self._get_parent(bgcolor, False, False, obj, **kwargs)
             mpl_preview(canvas.canvas, widget=canvas.canvas.central_widget)
         else:
@@ -247,7 +248,7 @@ class VisbrainObject(_VisbrainObj):
             if xyz:
                 vispy.scene.visuals.XYZAxis(parent=canvas.wc.scene)
             # view.camera = camera
-            if (sys.flags.interactive != 1) and show and CONFIG.show_pyqt_app:
+            if (sys.flags.interactive != 1) and show and cfg.show_pyqt_app:
                 vispy_app = ensure_vispy_app()
                 if vispy_app is not None:
                     vispy_app.run()

--- a/visbrain/tests/test_icons.py
+++ b/visbrain/tests/test_icons.py
@@ -15,7 +15,7 @@ def test_module_icon_uses_packaged_resource(monkeypatch):
         pytest.skip("Qt bindings are unavailable")
 
     from visbrain._pyqt_module import _PyQtModule
-    from visbrain.config import CONFIG
+    from visbrain.config import get_config
 
     class DummyWindow(_PyQtModule, QtWidgets.QMainWindow):
         """Minimal window exposing the ``show`` helper."""
@@ -25,7 +25,8 @@ def test_module_icon_uses_packaged_resource(monkeypatch):
             _PyQtModule.__init__(self, icon="brain_icon.svg", show_settings=False)
 
     # Guard against accidental GUI execution inside tests.
-    monkeypatch.setattr(CONFIG, "show_pyqt_app", False)
+    cfg = get_config()
+    monkeypatch.setattr(cfg, "show_pyqt_app", False)
 
     window = DummyWindow()
     window.show()


### PR DESCRIPTION
## Summary
- replace the old ConfigManager globals with a VisbrainConfig singleton and expose a get_config accessor plus configure_from_argv CLI parsing
- update GUI and utility call sites to rely on the accessor instead of importing CONFIG directly, keeping Matplotlib toggles in sync
- extend the config test suite to assert imports stay side-effect free and CLI arguments update logging and display flags

## Testing
- make flake
- pytest *(fails: missing libGL / OpenGL context in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd98b32950832892bb3c28f30c0e5b