### PR TITLE
Add context managers for GUI application lifecycles

### DIFF
--- a/visbrain/_pyqt_module.py
+++ b/visbrain/_pyqt_module.py
@@ -24,7 +24,7 @@ except ImportError:  # pragma: no cover - shiboken missing
     shiboken6 = None
 
 from .utils import set_widget_size, set_log_level
-from .config import PROFILER, ensure_qt_app, ensure_vispy_app, get_config
+from .config import PROFILER, get_config, qt_app, vispy_app
 from .io import path_to_tmp, clean_tmp, path_to_visbrain_data
 
 logger = logging.getLogger('visbrain')
@@ -112,49 +112,48 @@ class _PyQtModule(object):
 
     def show(self):
         """Display the graphical user interface."""
-        # Fixed size for the settings panel :
-        app = ensure_qt_app()
-        if hasattr(self, 'q_widget') and app is not None:
-            set_widget_size(app, self.q_widget, 23)
-            self.q_widget.setVisible(self._show_settings)
-        # Force the quick settings tab to be on the first tab :
-        if hasattr(self, 'QuickSettings'):
-            self.QuickSettings.setCurrentIndex(0)
-        # Set icon (if possible) :
-        if isinstance(self._module_icon, str):
-            try:
-                icon_resource = resources.files("visbrain.resources.icons")
-            except ModuleNotFoundError:  # pragma: no cover - packaging error
-                logger.debug("Icon package missing for %s", self._module_icon)
-            else:
-                icon_path = icon_resource.joinpath(self._module_icon)
-                if icon_path.is_file():
-                    try:
-                        with resources.as_file(icon_path) as icon_file:
-                            app_icon = QtGui.QIcon()
-                            app_icon.addFile(str(icon_file))
-                            self.setWindowIcon(app_icon)
-                    except FileNotFoundError:  # pragma: no cover - zip importer
+        with qt_app() as app:
+            if hasattr(self, 'q_widget') and app is not None:
+                set_widget_size(app, self.q_widget, 23)
+                self.q_widget.setVisible(self._show_settings)
+            # Force the quick settings tab to be on the first tab :
+            if hasattr(self, 'QuickSettings'):
+                self.QuickSettings.setCurrentIndex(0)
+            # Set icon (if possible) :
+            if isinstance(self._module_icon, str):
+                try:
+                    icon_resource = resources.files("visbrain.resources.icons")
+                except ModuleNotFoundError:  # pragma: no cover - packaging error
+                    logger.debug("Icon package missing for %s", self._module_icon)
+                else:
+                    icon_path = icon_resource.joinpath(self._module_icon)
+                    if icon_path.is_file():
+                        try:
+                            with resources.as_file(icon_path) as icon_file:
+                                app_icon = QtGui.QIcon()
+                                app_icon.addFile(str(icon_file))
+                                self.setWindowIcon(app_icon)
+                        except FileNotFoundError:  # pragma: no cover - zip importer
+                            logger.debug("No icon found (%s)" % self._module_icon)
+                    else:  # don't crash just for an icon...
                         logger.debug("No icon found (%s)" % self._module_icon)
-                else:  # don't crash just for an icon...
-                    logger.debug("No icon found (%s)" % self._module_icon)
-        else:
-            logger.debug("No icon passed as an input.")
-        # Tree description if log level is on debug :
-        if isinstance(self._need_description, list):
-            for k in self._need_description:
-                self._pyqt_title('Tree', eval('self.%s.describe_tree()' % k))
-        # Show and maximized the window :
-        if PROFILER and logger.level == 1:
-            self._pyqt_title('Profiler', '')
-            PROFILER.finish()
-        # If PyQt GUI :
-        cfg = get_config()
-        if cfg.show_pyqt_app:
-            self.showMaximized()
-            vispy_app = ensure_vispy_app()
-            if vispy_app is not None:
-                vispy_app.run()
+            else:
+                logger.debug("No icon passed as an input.")
+            # Tree description if log level is on debug :
+            if isinstance(self._need_description, list):
+                for k in self._need_description:
+                    self._pyqt_title('Tree', eval('self.%s.describe_tree()' % k))
+            # Show and maximized the window :
+            if PROFILER and logger.level == 1:
+                self._pyqt_title('Profiler', '')
+                PROFILER.finish()
+            # If PyQt GUI :
+            cfg = get_config()
+            if cfg.show_pyqt_app:
+                self.showMaximized()
+                with vispy_app() as active_vispy:
+                    if active_vispy is not None:
+                        active_vispy.run()
         # Finally clean the tmp folder :
         self._clean_tmp_folder()
 


### PR DESCRIPTION
## Summary
- add `qt_app` and `vispy_app` context managers that manage application lifecycle, handle reset requests, and respect configuration flags
- update `_PyQtModule.show` to rely on the new helpers for consistent GUI startup and shutdown
- expand configuration tests to exercise headless behaviour, nested contexts, and explicit teardown scenarios

## Testing
- make flake
- pytest *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68cd9cd7755c8328828f67ad2fd0ff03