### PR TITLE
Add headless configuration helper and env support

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -23,14 +23,11 @@ from _pytest.mark.expression import Expression
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 try:
-    from visbrain.config import get_config
+    from visbrain.config import configure_headless
 except Exception:  # pragma: no cover - defensive in CI without GUI libs
     CONFIG = None
 else:
-    CONFIG = get_config()
-    # Prevent Visbrain from attempting to display PyQt applications during
-    # tests when the GUI stack is available.
-    CONFIG.show_pyqt_app = False
+    CONFIG = configure_headless()
 
 # Paths whose tests should automatically be marked as requiring a GUI stack.
 _REPO_ROOT = Path(__file__).parent.resolve()


### PR DESCRIPTION
## Summary
- add a `show_gui` flag to `VisbrainConfig`, read `VISBRAIN_SHOW_GUI`, and expose a `configure_headless()` helper for automation
- update CLI parsing and pytest configuration to rely on the new helper while keeping backwards compatibility with `show_pyqt_app`
- expand the modernization documentation and configuration tests to cover environment overrides and the headless helper

## Testing
- make flake
- pytest *(fails: missing libGL.so.1 / GL ES 2.0 in the container)*
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest visbrain/tests/test_config.py *(fails: GL ES 2.0 library not found in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cee4ead338832891cb1cccf0105b49