### PR TITLE
Refactor Sleep GUI into MVC architecture

### DIFF
--- a/visbrain/gui/sleep/controller.py
+++ b/visbrain/gui/sleep/controller.py
@@ -1,0 +1,256 @@
+"""Controller coordinating Sleep model and view interactions."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from visbrain.config import PROFILER
+from visbrain.utils import MouseEventControl, color2vb
+
+from .interface import UiElements
+from .visuals import Visuals
+
+
+class SleepController(UiElements, Visuals, MouseEventControl):
+    """Encapsulate business logic for the Sleep GUI."""
+
+    def __init__(self, model, view, *, axis=True, config_file=None):
+        object.__setattr__(self, "_model", model)
+        object.__setattr__(self, "_view", view)
+
+        # -------------------- GUI state --------------------
+        self._config_file = config_file
+        self._annot_mark = np.array([])
+        self._ax = axis
+
+        # Default rendering parameters
+        self._lw = 1.0
+        self._lwhyp = 2
+        self._defwin = 30.0
+        self._defstd = 5.0
+        self._chancolor = '#292824'
+        self._hypcolor = {
+            -1: '#8bbf56',
+            0: '#56bf8b',
+            1: '#aabcce',
+            2: '#405c79',
+            3: '#0b1c2c',
+            4: '#bf5656',
+        }
+        self._indicol = '#e74c3c'
+        self._defcmap = 'viridis'
+        self._defspin = color2vb('#d73737')
+        self._defsw = color2vb('#56bf8b')
+        self._defkc = color2vb('#b45a3c')
+        self._defrem = color2vb('#6684e1')
+        self._defmt = color2vb('#FE8625')
+        self._defpeaks = '#b854d4'
+        self._spinsym = 'x'
+        self._swsym = 'o'
+        self._kcsym = 'diamond'
+        self._remsym = 'triangle_down'
+        self._mtsym = 'star'
+        self._peaksym = 'disc'
+
+        view.set_default_state()
+
+        MouseEventControl.__init__(self)
+
+        # Harmonize hypnogram colors with conversion tables
+        hconvinv = self._model.hconvinv
+        if self._model.hconv != hconvinv:
+            hypc = self._hypcolor.copy()
+            for key in self._model.hconv.keys():
+                self._hypcolor[key] = hypc[hconvinv[key]]
+
+        self._get_data_info()
+        PROFILER("Data info")
+
+        PROFILER("Initialize GUI interactions", as_type='title')
+        UiElements.__init__(self)
+
+        for attr in (
+            '_chanCanvas',
+            '_specCanvas',
+            '_hypCanvas',
+            '_topoCanvas',
+            '_TimeAxis',
+        ):
+            setattr(self._view, attr, getattr(self, attr))
+
+        view.create_cameras(len(self))
+
+        PROFILER("Initialize visual elements", as_type='title')
+        Visuals.__init__(self)
+
+        self._fcns_on_creation()
+        PROFILER("Functions on creation")
+
+    # ------------------------------------------------------------------
+    # Delegation helpers
+    # ------------------------------------------------------------------
+    def __getattr__(self, name):
+        try:
+            return getattr(self._view, name)
+        except AttributeError as err:
+            raise AttributeError(name) from err
+
+    # ------------------------------------------------------------------
+    # Model proxies
+    # ------------------------------------------------------------------
+    def __len__(self):
+        return len(self._model)
+
+    def __getitem__(self, key):
+        return self._model[key]
+
+    @property
+    def _data(self):
+        return self._model.data
+
+    @_data.setter
+    def _data(self, value):
+        self._model.data = value
+
+    @property
+    def _hypno(self):
+        return self._model.hypno
+
+    @_hypno.setter
+    def _hypno(self, value):
+        self._model.hypno = value
+
+    @property
+    def _time(self):
+        return self._model.time
+
+    @_time.setter
+    def _time(self, value):
+        self._model.time = value
+
+    @property
+    def _channels(self):
+        return self._model.channels
+
+    @_channels.setter
+    def _channels(self, value):
+        self._model.channels = value
+
+    @property
+    def _href(self):
+        return self._model.href
+
+    @_href.setter
+    def _href(self, value):
+        self._model.href = value
+
+    @property
+    def _hconv(self):
+        return self._model.hconv
+
+    @_hconv.setter
+    def _hconv(self, value):
+        self._model.hconv = value
+
+    @property
+    def _hconvinv(self):
+        return self._model.hconvinv
+
+    @property
+    def _sf(self):
+        return self._model.sf
+
+    @_sf.setter
+    def _sf(self, value):
+        self._model.sf = value
+
+    @property
+    def _sfori(self):
+        return self._model.sfori
+
+    @_sfori.setter
+    def _sfori(self, value):
+        self._model.sfori = value
+
+    @property
+    def _dsf(self):
+        return self._model.dsf
+
+    @_dsf.setter
+    def _dsf(self, value):
+        self._model.dsf = value
+
+    @property
+    def _N(self):
+        return self._model.n_points
+
+    @_N.setter
+    def _N(self, value):
+        self._model.n_points = value
+
+    @property
+    def _file(self):
+        return self._model.file
+
+    @_file.setter
+    def _file(self, value):
+        self._model.file = value
+
+    @property
+    def _annot_file(self):
+        return self._model.annotations
+
+    @_annot_file.setter
+    def _annot_file(self, value):
+        self._model.annotations = value
+
+    @property
+    def _datainfo(self):
+        return self._model.datainfo
+
+    @_datainfo.setter
+    def _datainfo(self, value):
+        self._model.datainfo = value
+
+    @property
+    def _custom_detections(self):
+        return self._model.custom_detections
+
+    # ------------------------------------------------------------------
+    # Initialization helpers
+    # ------------------------------------------------------------------
+    def _get_data_info(self):
+        return self._model.refresh_data_info()
+
+    def _fcns_on_creation(self):
+        self._fcn_grid_toggle()
+        self._fcn_scorwin_indicator_toggle()
+        self._fcn_sigwin_settings()
+        self._fcn_slider_move()
+        self._chanChecks[0].setChecked(True)
+        self._hypLabel.setVisible(self.menuDispHypno.isChecked())
+        self._fcn_chan_viz()
+        self._fcn_chan_sym_amp()
+        self._fcn_info_update()
+        self._fcn_hypno_to_score()
+        self._SpecW.setVisible(True)
+        self._HypW.setVisible(True)
+        self._TimeAxisW.setVisible(True)
+        if self._config_file is not None:
+            self._load_config(filename=self._config_file)
+        if self._annot_file is not None:
+            self._load_annotation_table(filename=self._annot_file)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def replace_detections(self, dtype, method):
+        meth_names = ('spindle', 'sw', 'kc', 'rem', 'mt', 'peak')
+        if dtype not in meth_names:
+            raise ValueError(
+                "dtype should be a string. Choose between %s" % ', '.join(meth_names)
+            )
+        if not hasattr(method, '__call__'):
+            raise AssertionError("method must be callable")
+        self._model.replace_detection(dtype, method)
+        self._fcn_switch_detection()

--- a/visbrain/gui/sleep/sleep.py
+++ b/visbrain/gui/sleep/sleep.py
@@ -1,395 +1,118 @@
-"""Top level Sleep class."""
-import logging
+"""Top-level Sleep façade assembling model, view and controller."""
 
-import numpy as np
+from __future__ import annotations
 
-import vispy.scene.cameras as viscam
+from typing import Optional
 
-from .interface import UiInit, UiElements
-from .model import SleepDataset
-from .visuals import Visuals
 from visbrain._pyqt_module import _PyQtModule
-from visbrain.utils import (FixedCam, color2vb, MouseEventControl)
 from visbrain.config import PROFILER
 
-logger = logging.getLogger('visbrain')
+from .controller import SleepController
+from .model import SleepDataset
+from .view import SleepView
 
 
-class Sleep(_PyQtModule, UiInit, Visuals, UiElements, MouseEventControl):
-    """Visualize and edit sleep data.
+class Sleep(_PyQtModule):
+    """Visualize and edit sleep data using a model/view/controller split."""
 
-    Use this module to :
+    def __init__(
+        self,
+        data=None,
+        hypno=None,
+        config_file=None,
+        annotations=None,
+        channels=None,
+        sf=None,
+        downsample=100.0,
+        axis=True,
+        href=None,
+        preload=True,
+        use_mne=False,
+        kwargs_mne=None,
+        *,
+        verbose=None,
+        model: Optional[SleepDataset] = None,
+        view: Optional[SleepView] = None,
+        controller: Optional[SleepController] = None,
+    ) -> None:
+        if href is None:
+            href = ['art', 'wake', 'rem', 'n1', 'n2', 'n3']
+        if kwargs_mne is None:
+            kwargs_mne = {}
 
-        * Load and visualize polysomnographic data and spectrogram.
-        * Load, edit and save hypnogram from the interface
-        * Perform automatic events detection
-        * Further signal processing tools (de-mean, de-trend and filtering)
-        * Topographic data visualization
+        super().__init__(verbose=verbose, icon='sleep_icon.svg')
 
-    Sleep has been developped in collaboration with Raphael Vallat.
-
-    Parameters
-    ----------
-    data : string, array_like | None
-        Polysomnographic data. Must either be a path to a supported file (see
-        notes) or an array of raw data of shape (n_channels, n_pts). If None,
-        a dialog window to load the file should appear.
-    hypno : array_like | None
-        Hypnogram data. Should be a raw vector of shape (n_pts,)
-    config_file : string | None
-        Path to the configuration file (.txt)
-    annotations : string | None
-        Path to the annotation file (.txt, .csv). Alternatively, you can pass
-        an annotation instance of MNE or simply an (N,) array describing
-        the onset.
-    channels : list | None
-        List of channel names. The length of this list must be n_channels.
-    sf : float | None
-        The sampling frequency of raw data.
-    downsample : float | 100.
-        The downsampling frequency for the data and hypnogram raw data.
-    axis : bool | False
-        Specify if each axis have to contains its own axis. Be carefull
-        with this option, the rendering can be much slower.
-    href : list | ['art', 'wake', 'rem', 'n1', 'n2', 'n3']
-        List of sleep stages. This list can be used to changed the display
-        order into the GUI.
-    preload : bool | True
-        Preload data into memory. For large datasets, turn this parameter to
-        True.
-    use_mne : bool | False
-        Force to load the file using mne.io functions.
-    kwargs_mne : dict | {}
-        Dictionary to pass to the mne.io loading function.
-
-    Notes
-    -----
-    .. note::
-        * Supported polysomnographic files : by default, Sleep support .vhdr
-          (BrainVision), .eeg (Elan), .trc (Micromed) and .edf (European Data
-          Format). If mne-python is installed, this default list of supported
-          files is extended to .cnt, .egi, .mff, .edf, .bdf, .gdf, .set, .vhdr.
-        * Supported hypnogram files : by default, Sleep support .txt, .csv and
-          .hyp hypnogram files.
-
-    .. deprecated:: 0.3.4
-        Input arguments `file` and `hypno_file` has been deprecated in 0.3.4
-        release. Use instead the `data` and `hypno` inputs.
-    """
-
-    def __init__(self, data=None, hypno=None, config_file=None,
-                 annotations=None, channels=None, sf=None, downsample=100.,
-                 axis=True, href=['art', 'wake', 'rem', 'n1', 'n2', 'n3'],
-                 preload=True, use_mne=False, kwargs_mne={}, verbose=None,
-                 model=None):
-        """Init."""
-        _PyQtModule.__init__(self, verbose=verbose, icon='sleep_icon.svg')
-        # ====================== APP CREATION ======================
-        UiInit.__init__(self)
-
-        # Set default GUI state :
-        self._set_default_state()
-
-        # Mouse control :
-        MouseEventControl.__init__(self)
-
-        # ====================== LOAD FILE ======================
         PROFILER("Import file", as_type='title')
         if model is None:
-            model = SleepDataset(data, channels, sf, hypno, href, preload,
-                                 use_mne, downsample, kwargs_mne,
-                                 annotations)
+            model = SleepDataset(
+                data,
+                channels,
+                sf,
+                hypno,
+                href,
+                preload,
+                use_mne,
+                downsample,
+                kwargs_mne,
+                annotations,
+            )
         elif not isinstance(model, SleepDataset):
             raise TypeError("model must be an instance of SleepDataset")
+
         self._model = model
 
-        # ====================== VARIABLES ======================
-        # Check all data :
-        self._config_file = config_file
-        self._annot_mark = np.array([])
-        self._ax = axis
-        # ---------- Default line width ----------
-        self._lw = 1.
-        self._lwhyp = 2
-        self._defwin = 30.
-        self._defstd = 5.
-        # ---------- Default colors ----------
-        self._chancolor = '#292824'
-        # self._hypcolor = '#292824'
-        # Hypnogram color :
-        self._hypcolor = {-1: '#8bbf56', 0: '#56bf8b', 1: '#aabcce',
-                          2: '#405c79', 3: '#0b1c2c', 4: '#bf5656'}
-        # Convert color :
-        hconvinv = self._model.hconvinv
-        if self._model.hconv != hconvinv:
-            hypc = self._hypcolor.copy()
-            for k in self._model.hconv.keys():
-                self._hypcolor[k] = hypc[hconvinv[k]]
-        self._indicol = '#e74c3c'
-        # Default spectrogram colormap :
-        self._defcmap = 'viridis'
-        # Spindles / REM / Peaks colors :
-        self._defspin = color2vb('#d73737')
-        self._defsw = color2vb('#56bf8b')
-        self._defkc = color2vb('#b45a3c')
-        self._defrem = color2vb('#6684e1')
-        self._defmt = color2vb('#FE8625')
-        self._defpeaks = '#b854d4'
-        # ---------- Symbol ----------
-        self._spinsym = 'x'
-        self._swsym = 'o'
-        self._kcsym = 'diamond'
-        self._remsym = 'triangle_down'
-        self._mtsym = 'star'
-        self._peaksym = 'disc'
-        # ---------- Custom detections ----------
-        # Get some data info (min / max / std / mean)
-        self._get_data_info()
-        PROFILER("Data info")
+        if view is not None and not isinstance(view, SleepView):
+            raise TypeError("view must be an instance of SleepView")
+        self._view = view or SleepView()
+        self.q_widget = self._view
 
-        # ====================== USER & GUI INTERACTION  ======================
-        # User <-> GUI :
-        PROFILER("Initialize GUI interactions", as_type='title')
-        UiElements.__init__(self)
+        if controller is not None and not isinstance(controller, SleepController):
+            raise TypeError("controller must be an instance of SleepController")
+        self._controller = controller or SleepController(
+            self._model,
+            self._view,
+            axis=axis,
+            config_file=config_file,
+        )
 
-        # ====================== CAMERAS ======================
-        self._cam_creation()
+    # ------------------------------------------------------------------
+    # Composition accessors
+    # ------------------------------------------------------------------
+    @property
+    def controller(self) -> SleepController:
+        return self._controller
 
-        # ====================== OBJECTS CREATION ======================
-        PROFILER("Initialize visual elements", as_type='title')
-        Visuals.__init__(self)
+    @property
+    def view(self) -> SleepView:
+        return self._view
 
-        # ====================== FUNCTIONS ON LOAD ======================
-        self._fcns_on_creation()
-        PROFILER("Functions on creation")
+    @property
+    def model(self) -> SleepDataset:
+        return self._model
 
+    # ------------------------------------------------------------------
+    # Delegation helpers
+    # ------------------------------------------------------------------
+    def __getattr__(self, name):
+        try:
+            return getattr(self._controller, name)
+        except AttributeError:
+            try:
+                return getattr(self._view, name)
+            except AttributeError as err:
+                raise AttributeError(name) from err
+
+    # ------------------------------------------------------------------
+    # Basic collection protocol
+    # ------------------------------------------------------------------
     def __len__(self):
-        """Return the number of channels."""
-        return len(self._model)
+        return len(self._controller)
 
     def __getitem__(self, key):
-        """Return corresponding data info."""
-        return self._model[key]
+        return self._controller[key]
 
+    # ------------------------------------------------------------------
+    # Public API proxies
+    # ------------------------------------------------------------------
     def replace_detections(self, dtype, method):
-        """Replace the default detection methods.
-
-        Parameters
-        ----------
-        dtype : string
-            Name of the method to replace. Should be 'spindle', 'sw' (slow
-            waves), 'kc' (k-complexes), 'rem' (rapid eye movements), 'mt'
-            (muscle twitches) or 'peak'.
-        method : function
-            Function to replace the detection. The function should take as an
-            input :
-
-                * A vector array of data of shape (n_time_points,)
-                * The sampling frequency (float)
-                * The time vector of shape (n_time_points,)
-                * A vector array for the hypnogram of shape (n_time_points,)
-
-            Then, the function should return indices of relevant events.
-            Returned indices should either be :
-
-                *  An array of shape (n_events, 2) where `n_events` describe
-                   the number of detected events. The first and second columns
-                   of the array respectively describe where detected events
-                   start and finished.
-                * A boolean vector of shape (n_time_points,) where True values
-                  refer to detected events.
-                * An array which contains consecutive indices of detected
-                  events.
-
-        Examples
-        --------
-        >>> def method(data, sf, hypno):
-        >>>     # Do stuff
-        >>>     indices = ...
-        >>>     return indices
-        """
-        # Type checking :
-        meth_names = ('spindle', 'sw', 'kc', 'rem', 'mt', 'peak')
-        if dtype not in meth_names:
-            raise ValueError("dtype should be a string. Choose between "
-                             "%s" % ', '.join(meth_names))
-        assert hasattr(method, '__call__')
-        # Save the method :
-        self._model.replace_detection(dtype, method)
-        # Set stack detections enable / disable :
-        self._fcn_switch_detection()
-
-    ###########################################################################
-    # SUB-FONCTIONS
-    ###########################################################################
-    def _get_data_info(self):
-        """Get some info about data (min, max, std, mean, dist)."""
-        return self._model.refresh_data_info()
-
-    # ------------------------------------------------------------------
-    # Data accessors proxying to the model layer
-    # ------------------------------------------------------------------
-    @property
-    def _data(self):
-        return self._model.data
-
-    @_data.setter
-    def _data(self, value):
-        self._model.data = value
-
-    @property
-    def _hypno(self):
-        return self._model.hypno
-
-    @_hypno.setter
-    def _hypno(self, value):
-        self._model.hypno = value
-
-    @property
-    def _time(self):
-        return self._model.time
-
-    @_time.setter
-    def _time(self, value):
-        self._model.time = value
-
-    @property
-    def _channels(self):
-        return self._model.channels
-
-    @_channels.setter
-    def _channels(self, value):
-        self._model.channels = value
-
-    @property
-    def _href(self):
-        return self._model.href
-
-    @_href.setter
-    def _href(self, value):
-        self._model.href = value
-
-    @property
-    def _hconv(self):
-        return self._model.hconv
-
-    @_hconv.setter
-    def _hconv(self, value):
-        self._model.hconv = value
-
-    @property
-    def _hconvinv(self):
-        return self._model.hconvinv
-
-    @property
-    def _sf(self):
-        return self._model.sf
-
-    @_sf.setter
-    def _sf(self, value):
-        self._model.sf = value
-
-    @property
-    def _sfori(self):
-        return self._model.sfori
-
-    @_sfori.setter
-    def _sfori(self, value):
-        self._model.sfori = value
-
-    @property
-    def _dsf(self):
-        return self._model.dsf
-
-    @_dsf.setter
-    def _dsf(self, value):
-        self._model.dsf = value
-
-    @property
-    def _N(self):
-        return self._model.n_points
-
-    @_N.setter
-    def _N(self, value):
-        self._model.n_points = value
-
-    @property
-    def _file(self):
-        return self._model.file
-
-    @_file.setter
-    def _file(self, value):
-        self._model.file = value
-
-    @property
-    def _annot_file(self):
-        return self._model.annotations
-
-    @_annot_file.setter
-    def _annot_file(self, value):
-        self._model.annotations = value
-
-    @property
-    def _datainfo(self):
-        return self._model.datainfo
-
-    @_datainfo.setter
-    def _datainfo(self, value):
-        self._model.datainfo = value
-
-    @property
-    def _custom_detections(self):
-        return self._model.custom_detections
-
-    def _set_default_state(self):
-        """Set the default window state."""
-        # ================= TAB =================
-        self._DetectionTab.setCurrentIndex(0)
-        self._stacked_panels.setCurrentIndex(0)
-        self._stacked_tools.setCurrentIndex(0)
-        self._stacked_detections.setCurrentIndex(0)
-
-    def _cam_creation(self):
-        """Create a set of cameras."""
-        # ------------------- Channels -------------------
-        self._chanCam = []
-        for k in range(len(self)):
-            self._chanCam.append(FixedCam())  # viscam.PanZoomCamera()
-        # ------------------- Spectrogram -------------------
-        self._speccam = FixedCam()  # viscam.PanZoomCamera()
-        self._specCanvas.set_camera(self._speccam)
-        # ------------------- Hypnogram -------------------
-        self._hypcam = FixedCam()  # viscam.PanZoomCamera()
-        self._hypCanvas.set_camera(self._hypcam)
-        # ------------------- Topoplot -------------------
-        self._topocam = viscam.PanZoomCamera()
-        self._topoCanvas.set_camera(self._topocam)
-        # ------------------- Time axis -------------------
-        self._timecam = FixedCam()
-        self._TimeAxis.set_camera(self._timecam)
-
-        # Keep all cams :
-        self._allCams = (self._chanCam, self._speccam, self._hypcam,
-                         self._topocam, self._timecam)
-
-    def _fcns_on_creation(self):
-        """Applied on creation."""
-        self._fcn_grid_toggle()
-        self._fcn_scorwin_indicator_toggle()
-        self._fcn_sigwin_settings()
-        self._fcn_slider_move()
-        self._chanChecks[0].setChecked(True)
-        self._hypLabel.setVisible(self.menuDispHypno.isChecked())
-        self._fcn_chan_viz()
-        self._fcn_chan_sym_amp()
-        self._fcn_info_update()
-        self._fcn_hypno_to_score()
-        # Set objects visible :
-        self._SpecW.setVisible(True)
-        self._HypW.setVisible(True)
-        self._TimeAxisW.setVisible(True)
-        # File to load :
-        if self._config_file is not None:  # Config file
-            self._load_config(filename=self._config_file)
-        if self._annot_file is not None:   # Annotation file
-            self._load_annotation_table(filename=self._annot_file)
+        return self._controller.replace_detections(dtype, method)

--- a/visbrain/gui/sleep/tests/test_controller.py
+++ b/visbrain/gui/sleep/tests/test_controller.py
@@ -1,0 +1,68 @@
+"""Unit tests targeting the Sleep controller without launching the façade."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+try:  # pragma: no cover - optional Qt bindings
+    from visbrain.qt import QtWidgets
+except ImportError:  # pragma: no cover - Qt not installed
+    QtWidgets = None
+
+from visbrain.gui.sleep.controller import SleepController
+from visbrain.gui.sleep.model import SleepDataset
+from visbrain.gui.sleep.view import SleepView
+
+
+pytestmark = [
+    pytest.mark.skipif(QtWidgets is None, reason="Qt bindings are unavailable"),
+]
+
+
+@pytest.fixture(scope="module")
+def controller_instance():
+    """Build a controller with synthetic data for signal simulation tests."""
+    rng = np.random.default_rng(0)
+    data = rng.standard_normal((2, 600)).astype(np.float32)
+    hypno = np.zeros(600, dtype=float)
+    dataset = SleepDataset(
+        data,
+        channels=["Cz", "Pz"],
+        sf=100.0,
+        hypno=hypno,
+        href=['art', 'wake', 'rem', 'n1', 'n2', 'n3'],
+        preload=True,
+        use_mne=False,
+        downsample=100.0,
+        kwargs_mne={},
+        annotations=None,
+    )
+    view = SleepView()
+    return SleepController(dataset, view)
+
+
+def test_slider_simulation(controller_instance):
+    """Trigger slider related slots without GUI interaction."""
+    controller = controller_instance
+    controller._SigSlStep.setValue(2)
+    controller._SigWin.setValue(20)
+    controller._fcn_slider_settings()
+    controller._fcn_slider_move()
+
+
+def test_detection_command(controller_instance):
+    """Simulate detection combo box changes and command execution."""
+    controller = controller_instance
+    controller._ToolDetectChan.setCurrentIndex(0)
+    controller._ToolDetectType.setCurrentIndex(0)
+    controller._fcn_apply_detection()
+
+
+def test_scoring_window_toggle(controller_instance):
+    """Toggle scoring window visibility programmatically."""
+    controller = controller_instance
+    controller._ScorWinVisible.setChecked(False)
+    controller._fcn_scorwin_indicator_toggle()
+    controller._ScorWinVisible.setChecked(True)
+    controller._fcn_scorwin_indicator_toggle()

--- a/visbrain/gui/sleep/tests/test_sleep.py
+++ b/visbrain/gui/sleep/tests/test_sleep.py
@@ -12,6 +12,8 @@ except ImportError:  # pragma: no cover - Qt not installed
     QtWidgets = None
 
 from visbrain.gui import Sleep
+from visbrain.gui.sleep.controller import SleepController
+from visbrain.gui.sleep.view import SleepView
 from visbrain.io import path_to_visbrain_data
 from visbrain.tests._tests_visbrain import _TestVisbrain
 
@@ -42,6 +44,13 @@ pytestmark = [
 
 class TestSleep(_TestVisbrain):
     """Test sleep.py."""
+
+    def test_facade_components(self):
+        """Ensure façade exposes MVC components."""
+        assert isinstance(sp.controller, SleepController)
+        assert isinstance(sp.view, SleepView)
+        assert sp.model is sp.controller._model
+        assert sp.view is sp.controller._view
 
     ###########################################################################
     #                                TOOLS

--- a/visbrain/gui/sleep/view.py
+++ b/visbrain/gui/sleep/view.py
@@ -1,0 +1,59 @@
+"""View layer for the Sleep GUI module."""
+
+from __future__ import annotations
+
+import vispy.scene.cameras as viscam
+
+from visbrain.utils import FixedCam
+
+from .interface import UiInit
+
+
+class SleepView(UiInit):
+    """Encapsulate construction of the Qt widgets for the Sleep GUI."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._allCams = ()
+
+    # ------------------------------------------------------------------
+    # UI helpers
+    # ------------------------------------------------------------------
+    def set_default_state(self) -> None:
+        """Reset stacked widgets to their default page."""
+        self._DetectionTab.setCurrentIndex(0)
+        self._stacked_panels.setCurrentIndex(0)
+        self._stacked_tools.setCurrentIndex(0)
+        self._stacked_detections.setCurrentIndex(0)
+
+    def create_cameras(self, n_channels: int) -> None:
+        """Create and attach cameras to the different canvases."""
+        chan_cams = [FixedCam() for _ in range(n_channels)]
+        for canvas, camera in zip(self._chanCanvas, chan_cams):
+            canvas.set_camera(camera)
+
+        self._speccam = FixedCam()
+        self._specCanvas.set_camera(self._speccam)
+
+        self._hypcam = FixedCam()
+        self._hypCanvas.set_camera(self._hypcam)
+
+        self._topocam = viscam.PanZoomCamera()
+        self._topoCanvas.set_camera(self._topocam)
+
+        self._timecam = FixedCam()
+        self._TimeAxis.set_camera(self._timecam)
+
+        self._chanCam = chan_cams
+        self._allCams = (
+            self._chanCam,
+            self._speccam,
+            self._hypcam,
+            self._topocam,
+            self._timecam,
+        )
+
+    @property
+    def all_cameras(self):
+        """Return the tuple of cameras for controller usage."""
+        return self._allCams


### PR DESCRIPTION
## Summary
- add a SleepView class to assemble the Qt widgets and camera wiring for the sleep GUI
- implement SleepController to orchestrate model/view interactions and reuse the existing Visuals logic
- refactor Sleep into a façade that wires model, view, and controller while refreshing the related GUI tests and adding controller-level coverage

## Testing
- make flake
- pytest *(fails: libGL.so.1 missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf9c5eb0348328aa0f4190f36ac9d2