### PR TITLE
Add modernization phase 3 roadmap

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,10 +18,19 @@ import os
 from os.path import relpath, dirname
 import sys
 from datetime import date
+import importlib.util
+from pathlib import Path
 
 import sphinx_bootstrap_theme
 from sphinx_gallery.sorting import FileNameSortKey, ExplicitOrder
 from numpydoc import numpydoc, docscrape
+
+_ICONS_PATH = Path(__file__).resolve().parents[1] / "visbrain" / "resources" / "icons.py"
+_ICONS_SPEC = importlib.util.spec_from_file_location("visbrain.resources.icons", _ICONS_PATH)
+if _ICONS_SPEC is not None and _ICONS_SPEC.loader is not None:
+    _ICONS_MODULE = importlib.util.module_from_spec(_ICONS_SPEC)
+    _ICONS_SPEC.loader.exec_module(_ICONS_MODULE)
+    sys.modules["visbrain.resources.icons"] = _ICONS_MODULE
 
 import visbrain
 from visbrain.config import get_config
@@ -64,7 +73,7 @@ autodoc_default_flags = ['members', 'inherited-members', 'no-undoc-members']
 sphinx_gallery_conf = {
     # path to your examples scripts
     'examples_dirs': '../examples',
-    'sphinx_gallery': None,
+    'plot_gallery': False,
     'reference_url': {
         'visbrain': None,
         'matplotlib': 'http://matplotlib.org',
@@ -123,7 +132,7 @@ release = visbrain.__version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -328,11 +337,11 @@ latex_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    # 'python': ('http://docs.python.org/', None),
-    'numpy': ('http://docs.scipy.org/doc/numpy-dev/', None),
-    'scipy': ('http://scipy.github.io/devdocs/', None),
-    'matplotlib': ('http://matplotlib.org', None),
-    'nibabel': ('http://nipy.org/nibabel', None),
+    # 'python': ('https://docs.python.org/3/', None),
+    'numpy': ('https://numpy.org/doc/stable/', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy/', None),
+    'matplotlib': ('https://matplotlib.org/stable/', None),
+    'nibabel': ('https://nipy.org/nibabel/', None),
 }
 
 # -- Options for manual page output ---------------------------------------
@@ -393,7 +402,7 @@ texinfo_documents = [
 # -----------------------------------------------------------------------------
 
 def setup(app):
-    app.add_stylesheet("visbrain_styles.css")
+    app.add_css_file("visbrain_styles.css")
 
 
 def linkcode_resolve(domain, info):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -68,3 +68,4 @@ Contents
    modernization/phase-0
    modernization/phase-1
    modernization/phase-2
+   modernization/phase-3

--- a/docs/modernization/phase-3.rst
+++ b/docs/modernization/phase-3.rst
@@ -1,0 +1,64 @@
+Phase 3 — Widget regeneration and Qt 6 alignment
+================================================
+
+Overview
+--------
+
+Phase 3 focuses on regenerating the Qt widget stack so the GUI matches the
+runtime guarantees introduced earlier in the roadmap.  Legacy PyQt5 code paths
+are rewritten against Qt 6 idioms, packaging assets that were previously baked
+into ``*.ui`` files, and layering new view/controller helpers on top of the
+configuration facade delivered in Phase 2.  The deliverables keep automated
+testing headless-friendly while ensuring interactive launches feel native on the
+current desktop platforms.
+
+Baseline dependencies
+---------------------
+
+The regeneration effort continues to target the platform assumptions ratified in
+Phase 0 and codified throughout Phase 1:
+
+* **Qt binding**: PySide6 >= 6.7.1 remains the official GUI backend.  It ships
+  ``shiboken6`` wheels for every supported OS and tracks Qt 6 API behavior
+  closely, reducing the amount of adapter code the team must maintain.
+* **Python**: 3.9 through 3.12, ensuring alignment with NumPy, PySide6 and the
+  scientific stack we ship to end users.
+* **Operating systems**: Windows 10/11 (x86_64), macOS 12 Monterey or newer
+  (arm64 and x86_64), and Ubuntu 22.04 LTS or newer on x86_64.
+* **VisPy**: 0.13.0 or newer, matching the renderer minimum already pinned in
+  ``pyproject.toml`` and the requirements sets.
+
+Widget regeneration strategy
+----------------------------
+
+The regenerated widgets embrace Qt 6 patterns directly rather than layering
+compatibility shims.  Designers export fresh ``.ui`` definitions that PySide6 can
+consume without the ``pyside2-uic`` backport scripts, and controllers migrate to
+Qt's type-hinted signal/slot API.  ``VisbrainConfig`` continues to own feature
+flags (Matplotlib rendering, telemetry opt-ins and GUI visibility) so newly
+ported dialogs and editors respect the same toggles that Phase 2 introduced for
+tests and automation.
+
+Hosting regenerated applications
+--------------------------------
+
+Phase 2's lazy application factories now provide the execution surface for the
+Qt 6 widgets.  ``ensure_qt_app()`` and ``ensure_vispy_app()`` create
+``QApplication`` and VisPy ``Application`` instances on demand, so the refreshed
+GUIs register themselves by requesting the handles from the shared configuration
+rather than building their own globals.  The factories expose context managers
+and ``force`` flags, allowing regenerated widgets to request an interactive host
+in desktop sessions while remaining inert during headless test runs.  This keeps
+the event loop lifecycle centralized and prepares the ground for future plugins
+that will drop widgets into the same app container.
+
+Rollout and testing
+-------------------
+
+* Update GUI packages module-by-module, validating each rewrite with pytest
+  suites that exercise the lazy factories in headless mode.
+* Ship Sphinx gallery examples that open the rebuilt widgets via
+  ``ensure_qt_app(force=True)`` so documentation captures the new APIs.
+* Refresh contributor guides once the regenerated stack lands, highlighting the
+  PySide6 workflow, the supported Python/OS matrix and the VisPy baseline so
+  developers verify patches on the official matrix before submitting changes.


### PR DESCRIPTION
## Summary
- document the phase 3 modernization plan covering regenerated Qt widgets, supported platforms, and dependency baselines
- add the new roadmap entry to the modernization toctree
- refresh Sphinx configuration to load the icons helper, use modern APIs, and disable gallery execution during doc builds

## Testing
- make flake
- pytest *(fails: ImportError: libGL.so.1: cannot open shared object file)*
- make -C docs html *(fails: multiple documentation warnings/errors including missing `sphinx_gallery.sphinx_compatibility` helper)*

------
https://chatgpt.com/codex/tasks/task_e_68cfedc1f75083289672689a0f72aaba