### PR TITLE
Modernize brain UI for Qt6 high DPI

### DIFF
--- a/visbrain/gui/brain/interface/gui/brain_gui.py
+++ b/visbrain/gui/brain/interface/gui/brain_gui.py
@@ -16,14 +16,15 @@ from PySide6.QtGui import (QAction, QBrush, QColor, QConicalGradient,
     QIcon, QImage, QKeySequence, QLinearGradient,
     QPainter, QPalette, QPixmap, QRadialGradient,
     QTransform)
-from PySide6.QtWidgets import (QApplication, QCheckBox, QComboBox, QDoubleSpinBox,
-    QFrame, QGridLayout, QGroupBox, QHBoxLayout,
-    QHeaderView, QLabel, QLayout, QLineEdit,
-    QMainWindow, QMenu, QMenuBar, QProgressBar,
-    QPushButton, QScrollArea, QSizePolicy, QSlider,
-    QSpacerItem, QSpinBox, QSplitter, QStackedWidget,
-    QStatusBar, QTabWidget, QTableView, QTableWidget,
-    QTableWidgetItem, QToolButton, QVBoxLayout, QWidget)
+from PySide6.QtWidgets import (QAbstractScrollArea, QApplication, QCheckBox, QComboBox,
+    QDoubleSpinBox, QFrame, QGridLayout, QGroupBox,
+    QHBoxLayout, QHeaderView, QLabel, QLayout,
+    QLineEdit, QMainWindow, QMenu, QMenuBar,
+    QProgressBar, QPushButton, QScrollArea, QSizePolicy,
+    QSlider, QSpacerItem, QSpinBox, QSplitter,
+    QStackedWidget, QStatusBar, QTabWidget, QTableView,
+    QTableWidget, QTableWidgetItem, QToolButton, QVBoxLayout,
+    QWidget)
 
 class Ui_MainWindow(object):
     def setupUi(self, MainWindow):
@@ -161,14 +162,16 @@ class Ui_MainWindow(object):
         self.splitter = QSplitter(self.centralwidget)
         self.splitter.setObjectName(u"splitter")
         self.splitter.setOrientation(Qt.Horizontal)
+        self.splitter.setChildrenCollapsible(False)
+        self.splitter.setHandleWidth(12)
         self.q_widget = QWidget(self.splitter)
         self.q_widget.setObjectName(u"q_widget")
-        sizePolicy = QSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred)
+        sizePolicy = QSizePolicy(QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.Preferred)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.q_widget.sizePolicy().hasHeightForWidth())
         self.q_widget.setSizePolicy(sizePolicy)
-        self.q_widget.setMinimumSize(QSize(0, 0))
+        self.q_widget.setMinimumSize(QSize(360, 0))
         self.q_widget.setMaximumSize(QSize(16777215, 16777215))
         self.verticalLayout_4 = QVBoxLayout(self.q_widget)
         self.verticalLayout_4.setObjectName(u"verticalLayout_4")
@@ -961,6 +964,7 @@ class Ui_MainWindow(object):
         self.scrollArea_2.setObjectName(u"scrollArea_2")
         self.scrollArea_2.setFrameShape(QFrame.NoFrame)
         self.scrollArea_2.setWidgetResizable(True)
+        self.scrollArea_2.setSizeAdjustPolicy(QAbstractScrollArea.AdjustToContents)
         self.scrollAreaWidgetContents_2 = QWidget()
         self.scrollAreaWidgetContents_2.setObjectName(u"scrollAreaWidgetContents_2")
         self.scrollAreaWidgetContents_2.setGeometry(QRect(0, 0, 312, 392))
@@ -2376,6 +2380,9 @@ class Ui_MainWindow(object):
 
     def retranslateUi(self, MainWindow):
         MainWindow.setWindowTitle(QCoreApplication.translate("MainWindow", u"Brain", None))
+        MainWindow.setStyleSheet(QCoreApplication.translate("MainWindow", u"QMainWindow { font-size: 10pt; }\n"
+"QGroupBox { font-size: 11pt; }\n"
+"QLabel { font-size: 10pt; }", None))
         self.actionSave.setText(QCoreApplication.translate("MainWindow", u"Save", None))
         self.actionLoad.setText(QCoreApplication.translate("MainWindow", u"Load", None))
         self.actionCortical_repartition.setText(QCoreApplication.translate("MainWindow", u"Cortical repartition", None))
@@ -2504,6 +2511,9 @@ class Ui_MainWindow(object):
 #if QT_CONFIG(shortcut)
         self.menuScreenshot.setShortcut(QCoreApplication.translate("MainWindow", u"Ctrl+N", None))
 #endif // QT_CONFIG(shortcut)
+        self.QuickSettings.setStyleSheet(QCoreApplication.translate("MainWindow", u"QTabWidget::pane { border: 0; }\n"
+"QTabBar::tab { padding: 6px 12px; font-size: 10pt; }\n"
+"QTabBar::tab:selected { font-weight: 600; }", None))
 #if QT_CONFIG(tooltip)
         self.QuickSettings.setToolTip(QCoreApplication.translate("MainWindow", u"<html><head/><body><p><br/></p></body></html>", None))
 #endif // QT_CONFIG(tooltip)

--- a/visbrain/gui/brain/interface/gui/brain_gui.ui
+++ b/visbrain/gui/brain/interface/gui/brain_gui.ui
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <ui version="4.0">
  <class>MainWindow</class>
  <widget class="QMainWindow" name="MainWindow">
@@ -16,6 +16,11 @@
   <property name="windowTitle">
    <string>Brain</string>
   </property>
+  <property name="styleSheet">
+   <string>QMainWindow { font-size: 10pt; }
+QGroupBox { font-size: 11pt; }
+QLabel { font-size: 10pt; }</string>
+  </property>
   <property name="tabShape">
    <enum>QTabWidget::Rounded</enum>
   </property>
@@ -26,16 +31,22 @@
       <property name="orientation">
        <enum>Qt::Horizontal</enum>
       </property>
+      <property name="childrenCollapsible">
+       <bool>false</bool>
+      </property>
+      <property name="handleWidth">
+       <number>12</number>
+      </property>
       <widget class="QWidget" name="q_widget" native="true">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
        <property name="minimumSize">
         <size>
-         <width>0</width>
+         <width>360</width>
          <height>0</height>
         </size>
        </property>
@@ -51,6 +62,11 @@
         </property>
         <item>
          <widget class="QTabWidget" name="QuickSettings">
+          <property name="styleSheet">
+           <string>QTabWidget::pane { border: 0; }
+QTabBar::tab { padding: 6px 12px; font-size: 10pt; }
+QTabBar::tab:selected { font-weight: 600; }</string>
+          </property>
           <property name="maximumSize">
            <size>
             <width>16777215</width>
@@ -219,7 +235,7 @@ name</string>
                <item row="1" column="2">
                 <widget class="QComboBox" name="_obj_name_lst">
                  <property name="toolTip">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Color connectivity line according to :&lt;/p&gt;&lt;p&gt;- Their connectivity strength&lt;/p&gt;&lt;p&gt;- The number of connections per node&lt;/p&gt;&lt;p&gt;- The line density (use the radius to control the density)&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Input parameter : &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;c_colorby&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Color connectivity line according to :&lt;/p&gt;&lt;p&gt;- Their connectivity strength&lt;/p&gt;&lt;p&gt;- The number of connections per node&lt;/p&gt;&lt;p&gt;- The line density (use the radius to control the density)&lt;/p&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Input parameter : &lt;/span&gt;&lt;span style=" font-style:italic;"&gt;c_colorby&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                  </property>
                 </widget>
                </item>
@@ -493,7 +509,7 @@ name</string>
                      <item row="2" column="2">
                       <widget class="QComboBox" name="_brain_template">
                        <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Switch brain template.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Input parameter : &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;a_template&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Switch brain template.&lt;/p&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Input parameter : &lt;/span&gt;&lt;span style=" font-style:italic;"&gt;a_template&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                        </property>
                       </widget>
                      </item>
@@ -569,7 +585,7 @@ name</string>
                         </font>
                        </property>
                        <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use transparent or opaque brain.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Input parameter : &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;a_proj&lt;/span&gt; and &lt;span style=&quot; font-style:italic;&quot;&gt;a_opacity&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use transparent or opaque brain.&lt;/p&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Input parameter : &lt;/span&gt;&lt;span style=" font-style:italic;"&gt;a_proj&lt;/span&gt; and &lt;span style=" font-style:italic;"&gt;a_opacity&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                        </property>
                        <property name="text">
                         <string>Translucent</string>
@@ -797,7 +813,7 @@ name</string>
                       </widget>
                      </item>
                      <item row="1" column="2">
-                      <widget class="QComboBox" name="_roiDiv"/>
+                      <widget class="QComboBox" name="_roiDiv" />
                      </item>
                      <item row="2" column="1">
                       <widget class="Line" name="line_7">
@@ -959,7 +975,7 @@ name</string>
                       </widget>
                      </item>
                      <item row="0" column="0">
-                      <widget class="QTableView" name="_roiToAdd"/>
+                      <widget class="QTableView" name="_roiToAdd" />
                      </item>
                     </layout>
                    </item>
@@ -1107,7 +1123,7 @@ name</string>
                       </widget>
                      </item>
                      <item row="0" column="2">
-                      <widget class="QComboBox" name="_volDiv"/>
+                      <widget class="QComboBox" name="_volDiv" />
                      </item>
                      <item row="1" column="0">
                       <widget class="QLabel" name="label_58">
@@ -1122,7 +1138,7 @@ name</string>
                       </widget>
                      </item>
                      <item row="2" column="2">
-                      <widget class="QComboBox" name="_volCmap"/>
+                      <widget class="QComboBox" name="_volCmap" />
                      </item>
                      <item row="0" column="0">
                       <widget class="QLabel" name="label_57">
@@ -1319,7 +1335,7 @@ name</string>
                       </widget>
                      </item>
                      <item row="0" column="2">
-                      <widget class="QComboBox" name="_csDiv"/>
+                      <widget class="QComboBox" name="_csDiv" />
                      </item>
                      <item row="4" column="1">
                       <widget class="Line" name="line_69">
@@ -1547,6 +1563,9 @@ name</string>
                       <property name="widgetResizable">
                        <bool>true</bool>
                       </property>
+                      <property name="sizeAdjustPolicy">
+                       <enum>QAbstractScrollArea::AdjustToContents</enum>
+                      </property>
                       <widget class="QWidget" name="scrollAreaWidgetContents_2">
                        <property name="geometry">
                         <rect>
@@ -1643,7 +1662,7 @@ name</string>
                              <item row="1" column="2">
                               <widget class="QComboBox" name="_s_symbol">
                                <property name="toolTip">
-                                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Change sources symbol&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Input parameter : &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;s_symbol&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Change sources symbol&lt;/p&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Input parameter : &lt;/span&gt;&lt;span style=" font-style:italic;"&gt;s_symbol&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                                </property>
                                <item>
                                 <property name="text">
@@ -1717,7 +1736,7 @@ name</string>
                                <item>
                                 <widget class="QDoubleSpinBox" name="_s_radiusmin">
                                  <property name="toolTip">
-                                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Maximum radius for the sources.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Input parameter : &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;s_radiusmax&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Maximum radius for the sources.&lt;/p&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Input parameter : &lt;/span&gt;&lt;span style=" font-style:italic;"&gt;s_radiusmax&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                                  </property>
                                  <property name="decimals">
                                   <number>1</number>
@@ -1727,7 +1746,7 @@ name</string>
                                <item>
                                 <widget class="QDoubleSpinBox" name="_s_radiusmax">
                                  <property name="toolTip">
-                                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Minimum radius for the sources.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Input parameter : &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;s_radiusmin&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Minimum radius for the sources.&lt;/p&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Input parameter : &lt;/span&gt;&lt;span style=" font-style:italic;"&gt;s_radiusmin&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                                  </property>
                                  <property name="decimals">
                                   <number>1</number>
@@ -1781,7 +1800,7 @@ name</string>
                                <item row="1" column="1">
                                 <widget class="QDoubleSpinBox" name="_s_edge_width">
                                  <property name="toolTip">
-                                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Edge width.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Input parameter : &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;s_edgewidth&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Edge width.&lt;/p&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Input parameter : &lt;/span&gt;&lt;span style=" font-style:italic;"&gt;s_edgewidth&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                                  </property>
                                  <property name="decimals">
                                   <number>1</number>
@@ -1793,7 +1812,7 @@ name</string>
                                  <item>
                                   <widget class="QLineEdit" name="_s_edge_color">
                                    <property name="toolTip">
-                                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Edge color (&lt;span style=&quot; font-style:italic;&quot;&gt;if edge width is not 0.&lt;/span&gt;)&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Input parameter : &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;s_edgecolor&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Edge color (&lt;span style=" font-style:italic;"&gt;if edge width is not 0.&lt;/span&gt;)&lt;/p&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Input parameter : &lt;/span&gt;&lt;span style=" font-style:italic;"&gt;s_edgecolor&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                                    </property>
                                   </widget>
                                  </item>
@@ -1976,7 +1995,7 @@ name</string>
                                <item>
                                 <widget class="QLineEdit" name="_st_color">
                                  <property name="toolTip">
-                                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Edge color (&lt;span style=&quot; font-style:italic;&quot;&gt;if edge width is not 0.&lt;/span&gt;)&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Input parameter : &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;s_edgecolor&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Edge color (&lt;span style=" font-style:italic;"&gt;if edge width is not 0.&lt;/span&gt;)&lt;/p&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Input parameter : &lt;/span&gt;&lt;span style=" font-style:italic;"&gt;s_edgecolor&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                                  </property>
                                 </widget>
                                </item>
@@ -2029,7 +2048,7 @@ name</string>
                              <item row="0" column="2">
                               <widget class="QDoubleSpinBox" name="_st_font_size">
                                <property name="toolTip">
-                                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Font size of source's text.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Input parameter : &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;s_textsize&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Font size of source's text.&lt;/p&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Input parameter : &lt;/span&gt;&lt;span style=" font-style:italic;"&gt;s_textsize&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                                </property>
                                <property name="decimals">
                                 <number>1</number>
@@ -2052,7 +2071,7 @@ name</string>
                              <item row="2" column="2">
                               <widget class="QWidget" name="widget_2" native="true">
                                <property name="toolTip">
-                                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Offset along the x-axis (dx), y-axis (dy) and z-axis (dz)&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Input parameter : &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;s_textshift&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Offset along the x-axis (dx), y-axis (dy) and z-axis (dz)&lt;/p&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Input parameter : &lt;/span&gt;&lt;span style=" font-style:italic;"&gt;s_textshift&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                                </property>
                                <layout class="QHBoxLayout" name="horizontalLayout_3">
                                 <property name="margin">
@@ -2174,7 +2193,7 @@ name</string>
                          <item row="0" column="2">
                           <widget class="QDoubleSpinBox" name="_s_proj_radius">
                            <property name="toolTip">
-                            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Radius for the cortical projection / repartition. Every vertices arround each sources comprised in a sphere of radius &amp;quot;Radius&amp;quot; will be considered in the projection. &lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Input parameter : &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;t_radius&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Radius for the cortical projection / repartition. Every vertices arround each sources comprised in a sphere of radius &amp;quot;Radius&amp;quot; will be considered in the projection. &lt;/p&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Input parameter : &lt;/span&gt;&lt;span style=" font-style:italic;"&gt;t_radius&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                            </property>
                            <property name="decimals">
                             <number>1</number>
@@ -2286,7 +2305,7 @@ type</string>
                             </font>
                            </property>
                            <property name="toolTip">
-                            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If contribute is checked, the projection of a source can contribute to both hemisphere. If it's not checked, the projection is only performed on the hemisphere it belong to. If the source is perfectly centered (like Cz), the projection is forced to be on both hemisphere.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Input parameter : &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;t_contribute&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If contribute is checked, the projection of a source can contribute to both hemisphere. If it's not checked, the projection is only performed on the hemisphere it belong to. If the source is perfectly centered (like Cz), the projection is forced to be on both hemisphere.&lt;/p&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Input parameter : &lt;/span&gt;&lt;span style=" font-style:italic;"&gt;t_contribute&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                            </property>
                            <property name="text">
                             <string>Contribute</string>
@@ -2296,10 +2315,10 @@ type</string>
                          <item row="1" column="2">
                           <widget class="QComboBox" name="_s_proj_type">
                            <property name="toolTip">
-                            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Choose the projection type :&lt;/p&gt;&lt;p&gt;- &lt;span style=&quot; font-weight:600;&quot;&gt;Source's activity :&lt;/span&gt; project the s_data input parameter on the surface.&lt;/p&gt;&lt;p&gt;- &lt;span style=&quot; font-weight:600;&quot;&gt;Source's repartition :&lt;/span&gt; project the number of contributing sources per vertex.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Choose the projection type :&lt;/p&gt;&lt;p&gt;- &lt;span style=" font-weight:600;"&gt;Source's activity :&lt;/span&gt; project the s_data input parameter on the surface.&lt;/p&gt;&lt;p&gt;- &lt;span style=" font-weight:600;"&gt;Source's repartition :&lt;/span&gt; project the number of contributing sources per vertex.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                            </property>
                            <property name="whatsThis">
-                            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Choose the projection type :&lt;/p&gt;&lt;p&gt;- &lt;span style=&quot; font-weight:600;&quot;&gt;Source's activity :&lt;/span&gt; project the s_data input parameter on the surface.&lt;/p&gt;&lt;p&gt;- &lt;span style=&quot; font-weight:600;&quot;&gt;Source's repartition :&lt;/span&gt; project the number of contributing sources per vertex.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Choose the projection type :&lt;/p&gt;&lt;p&gt;- &lt;span style=" font-weight:600;"&gt;Source's activity :&lt;/span&gt; project the s_data input parameter on the surface.&lt;/p&gt;&lt;p&gt;- &lt;span style=" font-weight:600;"&gt;Source's repartition :&lt;/span&gt; project the number of contributing sources per vertex.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                            </property>
                            <item>
                             <property name="text">
@@ -2618,7 +2637,7 @@ ROI</string>
                        <item row="1" column="1">
                         <widget class="QComboBox" name="_c_dyn_meth">
                          <property name="toolTip">
-                          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Control the dynamic opacity so that stronger connections are more opaque to weaker connections.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Input parameter : &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;c_dynamic&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Control the dynamic opacity so that stronger connections are more opaque to weaker connections.&lt;/p&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Input parameter : &lt;/span&gt;&lt;span style=" font-style:italic;"&gt;c_dynamic&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                          </property>
                          <item>
                           <property name="text">
@@ -2706,7 +2725,7 @@ ROI</string>
                              <item>
                               <widget class="QDoubleSpinBox" name="_c_dyn_min">
                                <property name="toolTip">
-                                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Minimum opacity for the weaker connexions.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Input parameter : &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;c_dynamic&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Minimum opacity for the weaker connexions.&lt;/p&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Input parameter : &lt;/span&gt;&lt;span style=" font-style:italic;"&gt;c_dynamic&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                                </property>
                                <property name="decimals">
                                 <number>1</number>
@@ -2725,7 +2744,7 @@ ROI</string>
                              <item>
                               <widget class="QDoubleSpinBox" name="_c_dyn_max">
                                <property name="toolTip">
-                                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Maximum opacity for the stronger connexions.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Input parameter : &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;c_dynamic&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Maximum opacity for the stronger connexions.&lt;/p&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Input parameter : &lt;/span&gt;&lt;span style=" font-style:italic;"&gt;c_dynamic&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                                </property>
                                <property name="decimals">
                                 <number>1</number>
@@ -2763,7 +2782,7 @@ ROI</string>
                        <item row="0" column="1">
                         <widget class="QComboBox" name="_c_colorby">
                          <property name="toolTip">
-                          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Color connectivity line according to :&lt;/p&gt;&lt;p&gt;- Their connectivity strength&lt;/p&gt;&lt;p&gt;- The number of connections per node&lt;/p&gt;&lt;p&gt;- The line density (use the radius to control the density)&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Input parameter : &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;c_colorby&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Color connectivity line according to :&lt;/p&gt;&lt;p&gt;- Their connectivity strength&lt;/p&gt;&lt;p&gt;- The number of connections per node&lt;/p&gt;&lt;p&gt;- The line density (use the radius to control the density)&lt;/p&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Input parameter : &lt;/span&gt;&lt;span style=" font-style:italic;"&gt;c_colorby&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                          </property>
                          <item>
                           <property name="text">
@@ -2850,7 +2869,7 @@ width</string>
                      <item row="1" column="2">
                       <widget class="QDoubleSpinBox" name="_c_line_width">
                        <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Connectivity line width.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Input parameter : &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;c_linewidth&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Connectivity line width.&lt;/p&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Input parameter : &lt;/span&gt;&lt;span style=" font-style:italic;"&gt;c_linewidth&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                        </property>
                        <property name="decimals">
                         <number>1</number>
@@ -2964,7 +2983,7 @@ width</string>
                        <item>
                         <widget class="QLineEdit" name="_ts_color">
                          <property name="toolTip">
-                          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Time-serie's color.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Input parameter : &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;ts_color&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Time-serie's color.&lt;/p&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Input parameter : &lt;/span&gt;&lt;span style=" font-style:italic;"&gt;ts_color&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                          </property>
                         </widget>
                        </item>
@@ -2980,7 +2999,7 @@ width</string>
                      <item row="0" column="2">
                       <widget class="QDoubleSpinBox" name="_ts_width">
                        <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Width of the time-series&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Input parameter : &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;ts_width&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Width of the time-series&lt;/p&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Input parameter : &lt;/span&gt;&lt;span style=" font-style:italic;"&gt;ts_width&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                        </property>
                        <property name="decimals">
                         <number>1</number>
@@ -3091,7 +3110,7 @@ width</string>
                      <item row="1" column="2">
                       <widget class="QDoubleSpinBox" name="_ts_amp">
                        <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Amplitude of the time-series.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Input parameter : &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;ts_amp&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Amplitude of the time-series.&lt;/p&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Input parameter : &lt;/span&gt;&lt;span style=" font-style:italic;"&gt;ts_amp&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                        </property>
                        <property name="decimals">
                         <number>1</number>
@@ -3126,7 +3145,7 @@ width</string>
                      <item row="2" column="2">
                       <widget class="QDoubleSpinBox" name="_ts_line_width">
                        <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Line-width of each time-series.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Input parameter : &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;ts_lw&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Line-width of each time-series.&lt;/p&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Input parameter : &lt;/span&gt;&lt;span style=" font-style:italic;"&gt;ts_lw&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                        </property>
                        <property name="decimals">
                         <number>1</number>
@@ -3136,7 +3155,7 @@ width</string>
                      <item row="5" column="2">
                       <widget class="QWidget" name="widget" native="true">
                        <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Offset along the x-axis (dx), y-axis (dy) and z-axis (dz)&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Input parameter : &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;ts_dxyz&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Offset along the x-axis (dx), y-axis (dy) and z-axis (dz)&lt;/p&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Input parameter : &lt;/span&gt;&lt;span style=" font-style:italic;"&gt;ts_dxyz&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                        </property>
                        <layout class="QHBoxLayout" name="horizontalLayout_4">
                         <property name="spacing">
@@ -3289,7 +3308,7 @@ width</string>
                      <item row="0" column="2">
                       <widget class="QDoubleSpinBox" name="_pic_width">
                        <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Width of the pictures&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Input parameter : &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;pic_width&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Width of the pictures&lt;/p&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Input parameter : &lt;/span&gt;&lt;span style=" font-style:italic;"&gt;pic_width&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                        </property>
                        <property name="decimals">
                         <number>1</number>
@@ -3388,7 +3407,7 @@ width</string>
                      <item row="1" column="2">
                       <widget class="QDoubleSpinBox" name="_pic_height">
                        <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Height of the pictures.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Input parameter : &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;pic_height&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Height of the pictures.&lt;/p&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Input parameter : &lt;/span&gt;&lt;span style=" font-style:italic;"&gt;pic_height&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                        </property>
                        <property name="decimals">
                         <number>1</number>
@@ -3398,7 +3417,7 @@ width</string>
                      <item row="3" column="2">
                       <widget class="QWidget" name="widget_3" native="true">
                        <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Offset along the x-axis (dx), y-axis (dy) and z-axis (dz)&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Input parameter : &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;pic_dxyz&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Offset along the x-axis (dx), y-axis (dy) and z-axis (dz)&lt;/p&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Input parameter : &lt;/span&gt;&lt;span style=" font-style:italic;"&gt;pic_dxyz&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                        </property>
                        <layout class="QHBoxLayout" name="horizontalLayout_6">
                         <property name="spacing">
@@ -3571,7 +3590,7 @@ width</string>
                      <item row="0" column="2">
                       <widget class="QDoubleSpinBox" name="_vec_line_width">
                        <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Width of the pictures&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Input parameter : &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;pic_width&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Width of the pictures&lt;/p&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Input parameter : &lt;/span&gt;&lt;span style=" font-style:italic;"&gt;pic_width&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                        </property>
                        <property name="decimals">
                         <number>1</number>
@@ -3649,7 +3668,7 @@ size</string>
                      <item row="1" column="2">
                       <widget class="QDoubleSpinBox" name="_vec_arrow_size">
                        <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Height of the pictures.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Input parameter : &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;pic_height&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Height of the pictures.&lt;/p&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Input parameter : &lt;/span&gt;&lt;span style=" font-style:italic;"&gt;pic_height&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                        </property>
                        <property name="decimals">
                         <number>1</number>
@@ -3700,7 +3719,7 @@ size</string>
                      <item row="2" column="2">
                       <widget class="QComboBox" name="_vec_arrow_type">
                        <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Color connectivity line according to :&lt;/p&gt;&lt;p&gt;- Their connectivity strength&lt;/p&gt;&lt;p&gt;- The number of connections per node&lt;/p&gt;&lt;p&gt;- The line density (use the radius to control the density)&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Input parameter : &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;c_colorby&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Color connectivity line according to :&lt;/p&gt;&lt;p&gt;- Their connectivity strength&lt;/p&gt;&lt;p&gt;- The number of connections per node&lt;/p&gt;&lt;p&gt;- The line density (use the radius to control the density)&lt;/p&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Input parameter : &lt;/span&gt;&lt;span style=" font-style:italic;"&gt;c_colorby&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                        </property>
                        <item>
                         <property name="text">
@@ -3792,7 +3811,7 @@ type</string>
            </attribute>
            <layout class="QVBoxLayout" name="verticalLayout_2">
             <item>
-             <widget class="QWidget" name="_cbarWidget" native="true"/>
+             <widget class="QWidget" name="_cbarWidget" native="true" />
             </item>
             <item>
              <widget class="QWidget" name="UserMsgBox" native="true">
@@ -3802,7 +3821,7 @@ type</string>
                 <height>0</height>
                </size>
               </property>
-              <layout class="QHBoxLayout" name="horizontalLayout_52"/>
+              <layout class="QHBoxLayout" name="horizontalLayout_52" />
              </widget>
             </item>
            </layout>
@@ -3915,11 +3934,11 @@ type</string>
                </layout>
               </item>
              </layout>
-             <zorder></zorder>
+             <zorder />
             </widget>
            </item>
            <item>
-            <layout class="QHBoxLayout" name="vBrain"/>
+            <layout class="QHBoxLayout" name="vBrain" />
            </item>
           </layout>
          </item>
@@ -3928,15 +3947,15 @@ type</string>
        <widget class="QWidget" name="_crossecPage">
         <layout class="QVBoxLayout" name="verticalLayout_26">
          <item>
-          <layout class="QHBoxLayout" name="_axialLayout"/>
+          <layout class="QHBoxLayout" name="_axialLayout" />
          </item>
          <item>
           <layout class="QHBoxLayout" name="horizontalLayout_9">
            <item>
-            <layout class="QHBoxLayout" name="_coronLayout"/>
+            <layout class="QHBoxLayout" name="_coronLayout" />
            </item>
            <item>
-            <layout class="QHBoxLayout" name="_sagitLayout"/>
+            <layout class="QHBoxLayout" name="_sagitLayout" />
            </item>
           </layout>
          </item>
@@ -3968,11 +3987,11 @@ type</string>
       <property name="title">
        <string>Config</string>
       </property>
-      <addaction name="menuSaveGuiConfig"/>
-      <addaction name="menuSaveCbarConfig"/>
+      <addaction name="menuSaveGuiConfig" />
+      <addaction name="menuSaveCbarConfig" />
      </widget>
-     <addaction name="menuScreenshot"/>
-     <addaction name="menuConfig"/>
+     <addaction name="menuScreenshot" />
+     <addaction name="menuConfig" />
     </widget>
     <widget class="QMenu" name="menuLoad">
      <property name="title">
@@ -3982,15 +4001,15 @@ type</string>
       <property name="title">
        <string>Config</string>
       </property>
-      <addaction name="menuLoadGuiConfig"/>
-      <addaction name="menuLoadCbarConfig"/>
+      <addaction name="menuLoadGuiConfig" />
+      <addaction name="menuLoadCbarConfig" />
      </widget>
-     <addaction name="menuConfig_2"/>
+     <addaction name="menuConfig_2" />
     </widget>
-    <addaction name="menuSave"/>
-    <addaction name="menuLoad"/>
-    <addaction name="separator"/>
-    <addaction name="actionExit"/>
+    <addaction name="menuSave" />
+    <addaction name="menuLoad" />
+    <addaction name="separator" />
+    <addaction name="actionExit" />
    </widget>
    <widget class="QMenu" name="menuTransform">
     <property name="title">
@@ -4000,11 +4019,11 @@ type</string>
      <property name="title">
       <string>Run projection</string>
      </property>
-     <addaction name="menuCortProj"/>
-     <addaction name="menuCortRep"/>
+     <addaction name="menuCortProj" />
+     <addaction name="menuCortRep" />
     </widget>
-    <addaction name="menuRun_projection"/>
-    <addaction name="actionClean_projection"/>
+    <addaction name="menuRun_projection" />
+    <addaction name="actionClean_projection" />
    </widget>
    <widget class="QMenu" name="menuDisplay">
     <property name="title">
@@ -4014,33 +4033,33 @@ type</string>
      <property name="title">
       <string>Rotate</string>
      </property>
-     <addaction name="menuRotTop"/>
-     <addaction name="menuRotBottom"/>
-     <addaction name="menuRotLeft"/>
-     <addaction name="menuRotRight"/>
-     <addaction name="menuRotFront"/>
-     <addaction name="menuRotBack"/>
+     <addaction name="menuRotTop" />
+     <addaction name="menuRotBottom" />
+     <addaction name="menuRotLeft" />
+     <addaction name="menuRotRight" />
+     <addaction name="menuRotFront" />
+     <addaction name="menuRotBack" />
     </widget>
-    <addaction name="actionObjects"/>
-    <addaction name="menuDispQuickSettings"/>
-    <addaction name="menuDispBrain"/>
-    <addaction name="menuDispCrossec"/>
-    <addaction name="menuDispVol"/>
-    <addaction name="menuDispSources"/>
-    <addaction name="menuDispConnect"/>
-    <addaction name="menuDispROI"/>
-    <addaction name="menuDispCbar"/>
-    <addaction name="separator"/>
-    <addaction name="actionCamera_2"/>
-    <addaction name="menuRotate"/>
-    <addaction name="menuCamFly"/>
-    <addaction name="menuResetCam"/>
+    <addaction name="actionObjects" />
+    <addaction name="menuDispQuickSettings" />
+    <addaction name="menuDispBrain" />
+    <addaction name="menuDispCrossec" />
+    <addaction name="menuDispVol" />
+    <addaction name="menuDispSources" />
+    <addaction name="menuDispConnect" />
+    <addaction name="menuDispROI" />
+    <addaction name="menuDispCbar" />
+    <addaction name="separator" />
+    <addaction name="actionCamera_2" />
+    <addaction name="menuRotate" />
+    <addaction name="menuCamFly" />
+    <addaction name="menuResetCam" />
    </widget>
-   <addaction name="menuFiles"/>
-   <addaction name="menuDisplay"/>
-   <addaction name="menuTransform"/>
+   <addaction name="menuFiles" />
+   <addaction name="menuDisplay" />
+   <addaction name="menuTransform" />
   </widget>
-  <widget class="QStatusBar" name="statusbar"/>
+  <widget class="QStatusBar" name="statusbar" />
   <action name="actionSave">
    <property name="text">
     <string>Save</string>
@@ -4439,6 +4458,6 @@ type</string>
  <tabstops>
   <tabstop>QuickSettings</tabstop>
  </tabstops>
- <resources/>
- <connections/>
+ <resources />
+ <connections />
 </ui>

--- a/visbrain/gui/brain/interface/ui_elements/ui_atlas.py
+++ b/visbrain/gui/brain/interface/ui_elements/ui_atlas.py
@@ -282,7 +282,9 @@ class UiAtlas(object):
         """Reset ROIs selection."""
         # Unchecked all ROIs :
         for num in range(self._roiModel.rowCount()):
-            self._roiModel.item(num, 0).setCheckState(QtCore.Qt.Unchecked)
+            self._roiModel.item(num, 0).setCheckState(
+                QtCore.Qt.CheckState.Unchecked
+            )
 
     def _fcn_get_selected_rois(self):
         """Get the list of selected ROIs."""
@@ -290,7 +292,7 @@ class UiAtlas(object):
         all_idx = list(self.roi.get_labels()['index'])
         for num in range(self._roiModel.rowCount()):
             item = self._roiModel.item(num, 0)
-            if item.checkState():
+            if item.checkState() == QtCore.Qt.CheckState.Checked:
                 _roitoadd.append(all_idx[num])
         return _roitoadd
 


### PR DESCRIPTION
## Summary
- refresh the Brain Qt Designer file for Qt6 by adding high-DPI friendly styling, splitter ergonomics, and scroll area adjustments
- regenerate the auto-generated Qt wrapper so the runtime picks up the updated layout tweaks
- migrate ROI selection logic to Qt6 CheckState enums for consistent action handling

## Testing
- `pytest visbrain/gui/brain/tests` *(fails: missing libGL in container)*
- `PATH="$HOME/.pyenv/versions/3.12.10/bin:$PATH" make flake`


------
https://chatgpt.com/codex/tasks/task_e_68d014903cf08328be3e4fecb519bbad