### PR TITLE
Modernize GUI visuals with shared scene context

### DIFF
--- a/visbrain/gui/brain/tests/test_brain.py
+++ b/visbrain/gui/brain/tests/test_brain.py
@@ -7,6 +7,8 @@ from itertools import product
 from vispy.app.canvas import MouseEvent, KeyEvent
 # from vispy.util.keys import Key
 
+import vispy.visuals.transforms as vist
+
 from visbrain.gui import Brain
 from visbrain.objects import (SourceObj, ConnectObj, TimeSeries3DObj,
                               Picture3DObj, RoiObj, VolumeObj, CrossSecObj,
@@ -86,6 +88,14 @@ class TestBrain(_TestVisbrain):
     ###########################################################################
     #                                 BRAIN
     ###########################################################################
+    def test_visual_default_scene(self):
+        """The brain scene uses a dedicated transform node."""
+
+        assert vb._vbNode.parent is vb.view.wc.scene
+        assert isinstance(vb._vbNode.transform, vist.STTransform)
+        expected = (vb._gl_scale,) * 3
+        assert tuple(vb._vbNode.transform.scale) == expected
+
     def test_scene_rotation(self):
         """Test scene rotations/."""
         rotations = ['axial_0', 'coronal_0', 'sagittal_0',

--- a/visbrain/gui/brain/visuals.py
+++ b/visbrain/gui/brain/visuals.py
@@ -1,7 +1,6 @@
 """The BaseVisual class thath initialize all visual elements."""
 import logging
 
-from vispy import scene
 import vispy.visuals.transforms as vist
 
 from visbrain.objects import (CombineSources, CombineConnect,
@@ -9,6 +8,7 @@ from visbrain.objects import (CombineSources, CombineConnect,
                               CombineVectors, BrainObj, VolumeObj, RoiObj,
                               CrossSecObj)
 from visbrain.config import PROFILER
+from visbrain.visuals.context import create_scene_node
 
 logger = logging.getLogger('visbrain')
 
@@ -25,8 +25,12 @@ class Visuals(object):
     def __init__(self, canvas, **kwargs):
         """Init."""
         # Create a root node :
-        self._vbNode = scene.Node(name='Brain')
-        self._vbNode.transform = vist.STTransform(scale=[self._gl_scale] * 3)
+        transform = vist.STTransform(scale=[self._gl_scale] * 3)
+        self._vbNode = create_scene_node(
+            canvas,
+            name='Brain',
+            transform=transform,
+        )
         logger.debug("Brain rescaled " + str([self._gl_scale] * 3))
         PROFILER("Root node", level=1)
 

--- a/visbrain/gui/signal/tests/test_signal.py
+++ b/visbrain/gui/signal/tests/test_signal.py
@@ -26,6 +26,14 @@ class TestSignal(_TestVisbrain):
     ###########################################################################
     #                                 LABELS
     ###########################################################################
+    def test_visual_default_scene(self):
+        """Channel visuals attach to the expected scene graph."""
+
+        first_canvas = sig._chanCanvas[0]
+        node = sig._chan.node[0]
+        assert node.parent is first_canvas.wc.scene
+        assert sig._chan.mesh[0].parent is node
+
     def test_xlabel(self):
         """Test setting xlabel."""
         # Text :

--- a/visbrain/gui/sleep/tests/test_sleep.py
+++ b/visbrain/gui/sleep/tests/test_sleep.py
@@ -39,6 +39,15 @@ def test_facade_components(sleep_facade):
     assert sleep_facade.view is sleep_facade.controller._view
 
 
+def test_visual_scenegraph(sleep_facade):
+    """Channel visuals attach to the channel canvas scene."""
+
+    node = sleep_facade._chan.node[0]
+    canvas = sleep_facade._chanCanvas[0]
+    assert node.parent is canvas.wc.scene
+    assert sleep_facade._chan.mesh[0].parent is node
+
+
 def test_detection_flow_through_facade(sleep_facade, tmp_path):
     """Custom detections propagate through the full GUI stack."""
 

--- a/visbrain/gui/sleep/visuals/visuals.py
+++ b/visbrain/gui/sleep/visuals/visuals.py
@@ -16,6 +16,7 @@ from visbrain.utils import (color2vb, PrepareData, cmap_to_glsl)
 from visbrain.utils.sleep.event import _index_to_events
 from visbrain.visuals import TopoMesh, TFmapsMesh
 from visbrain.config import PROFILER
+from visbrain.visuals.context import create_scene_node
 
 logger = logging.getLogger('visbrain')
 
@@ -245,8 +246,7 @@ class ChannelPlot(PrepareData):
         for i, k in enumerate(channels):
             # ----------------------------------------------
             # Create a node parent :
-            node = scene.Node(name=k + 'plot')
-            node.parent = parent[i].wc.scene
+            node = create_scene_node(parent[i].wc, name=k + 'plot')
             self.node.append(node)
 
             # ----------------------------------------------

--- a/visbrain/visuals/__init__.py
+++ b/visbrain/visuals/__init__.py
@@ -1,6 +1,12 @@
 """Visual objects."""
 from .brain_visual import BrainMesh  # noqa
 from .cbar import *  # noqa
+from .context import (  # noqa
+    SceneContext,
+    create_scene_canvas,
+    create_scene_node,
+    scene_canvas,
+)
 from .grid_signal_visual import GridSignal  # noqa
 from .hypno_visual import Hypnogram  # noqa
 from .pic_visual import PicMesh  # noqa

--- a/visbrain/visuals/context.py
+++ b/visbrain/visuals/context.py
@@ -1,0 +1,168 @@
+"""Helpers for building VisPy scene graphs in a headless-friendly way."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any, Iterator, Mapping, Optional, Sequence
+
+from vispy import scene
+import vispy.visuals.transforms as vist
+
+from ..config import ensure_vispy_app, vispy_app
+
+__all__ = [
+    "SceneContext",
+    "create_scene_canvas",
+    "create_scene_node",
+    "scene_canvas",
+]
+
+
+@dataclass
+class SceneContext:
+    """Bundle a :class:`~vispy.scene.SceneCanvas` and the attached view."""
+
+    canvas: scene.SceneCanvas
+    view: scene.widgets.viewbox.ViewBox
+
+    @property
+    def scene(self) -> scene.Node:
+        """Return the root scene node backing the view."""
+
+        return self.view.scene
+
+    def create_node(
+        self,
+        *,
+        name: str | None = None,
+        transform: vist.BaseTransform | None = None,
+        scale: Sequence[float] | float | None = None,
+        translate: Sequence[float] | None = None,
+    ) -> scene.Node:
+        """Create a child node attached to this context's scene."""
+
+        return create_scene_node(
+            self.view,
+            name=name,
+            transform=transform,
+            scale=scale,
+            translate=translate,
+        )
+
+
+def _resolve_scene_parent(parent: Any) -> scene.Node:
+    """Return the scene graph node associated with *parent*.
+
+    Parameters
+    ----------
+    parent:
+        Object exposing a ``scene`` attribute (``SceneCanvas``/``ViewBox``), a
+        ``wc`` attribute (``VisbrainCanvas`` wrappers) or a :class:`SceneContext`.
+    """
+
+    if isinstance(parent, SceneContext):
+        return parent.scene
+    if isinstance(parent, scene.Node):
+        return parent
+    if hasattr(parent, "scene"):
+        scene_graph = getattr(parent, "scene")
+        if isinstance(scene_graph, scene.Node):
+            return scene_graph
+    if hasattr(parent, "wc"):
+        wc = getattr(parent, "wc")
+        return _resolve_scene_parent(wc)
+    if hasattr(parent, "canvas"):
+        canvas = getattr(parent, "canvas")
+        if isinstance(canvas, scene.SceneCanvas):
+            return canvas.scene
+    raise TypeError(
+        "Unable to resolve a scene graph node from %r" % (parent,)
+    )
+
+
+def create_scene_node(
+    parent: Any,
+    *,
+    name: str | None = None,
+    transform: vist.BaseTransform | None = None,
+    scale: Sequence[float] | float | None = None,
+    translate: Sequence[float] | None = None,
+) -> scene.Node:
+    """Create a :class:`~vispy.scene.Node` attached to *parent*.
+
+    The helper resolves the appropriate parent node and ensures the global
+    VisPy application exists using the Phase 2 lazy factories.
+    """
+
+    ensure_vispy_app()
+    parent_node = _resolve_scene_parent(parent)
+    node = scene.Node(name=name, parent=parent_node)
+
+    if transform is None and (scale is not None or translate is not None):
+        transform = vist.STTransform()
+
+    if transform is not None:
+        if scale is not None:
+            transform.scale = scale
+        if translate is not None:
+            transform.translate = translate
+        node.transform = transform
+
+    return node
+
+
+def create_scene_canvas(
+    *,
+    keys: str | None = "interactive",
+    bgcolor: str | Sequence[float] = "black",
+    size: Sequence[int] | None = None,
+    show: bool = False,
+    title: str | None = None,
+    view_kwargs: Optional[Mapping[str, Any]] = None,
+) -> SceneContext:
+    """Instantiate a :class:`SceneCanvas` and return its context wrapper."""
+
+    ensure_vispy_app()
+    canvas = scene.SceneCanvas(
+        keys=keys,
+        bgcolor=bgcolor,
+        show=show,
+        title=title,
+        size=size,
+    )
+    view = canvas.central_widget.add_view(**dict(view_kwargs or {}))
+    return SceneContext(canvas=canvas, view=view)
+
+
+@contextmanager
+def scene_canvas(
+    *,
+    keys: str | None = "interactive",
+    bgcolor: str | Sequence[float] = "black",
+    size: Sequence[int] | None = None,
+    show: bool = False,
+    title: str | None = None,
+    view_kwargs: Optional[Mapping[str, Any]] = None,
+    force_app: bool = False,
+) -> Iterator[SceneContext]:
+    """Context manager yielding a :class:`SceneContext`.
+
+    The manager cooperates with :func:`visbrain.config.vispy_app` so tests can
+    request canvases without leaking global application state.
+    """
+
+    ensure_vispy_app(force=force_app)
+    with vispy_app(force=force_app) as _:
+        context = create_scene_canvas(
+            keys=keys,
+            bgcolor=bgcolor,
+            size=size,
+            show=show,
+            title=title,
+            view_kwargs=view_kwargs,
+        )
+        try:
+            yield context
+        finally:
+            context.canvas.close()


### PR DESCRIPTION
## Summary
- add a `visbrain.visuals.context` module that exposes helpers for SceneCanvas creation and scene-graph node wiring while respecting the lazy VisPy app factories
- update Brain and Sleep visuals to build their root nodes through the shared helper and exercise the new flow with targeted tests for each GUI module
- expose the context helpers at the visuals package root so downstream code can opt into the shared entry points

## Testing
- /root/.pyenv/versions/3.12.10/bin/tox -e lint
- QT_QPA_PLATFORM=minimal XDG_RUNTIME_DIR=/tmp pytest visbrain/gui -k visual *(fails: Qt aborts while importing Signal UI stack in the headless container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0449c513c8328889e3aebbfccc744