### PR TITLE
Improve GUI accessibility and keyboard navigation

### DIFF
--- a/visbrain/gui/_accessibility.py
+++ b/visbrain/gui/_accessibility.py
@@ -1,0 +1,124 @@
+"""Accessibility helpers for Qt-based GUI widgets."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import List, Mapping, MutableMapping, Optional, Tuple
+
+from visbrain.qt import QtCore, QtGui, QtWidgets
+
+
+_Description = Tuple[str, str]
+
+_DEFAULT_ACCESSIBLE: Mapping[str, _Description] = {
+    "QuickSettings": (
+        "Quick settings",
+        "Tabbed container holding configuration panels for the active visualization.",
+    ),
+    "_stacked_panels": (
+        "Visualization panel stack",
+        "Switches between panel groups that expose visualization controls.",
+    ),
+    "_stacked_tools": (
+        "Tool stack",
+        "Groups advanced tools such as detections and processing controls.",
+    ),
+    "_stacked_detections": (
+        "Detection stack",
+        "Shows the configuration panels for automated detection workflows.",
+    ),
+    "statusbar": (
+        "Status messages",
+        "Displays contextual status updates for the active visualization.",
+    ),
+    "progressBar": (
+        "Processing progress",
+        "Indicates the completion state of long running computations.",
+    ),
+    "userRotationPanel": (
+        "Camera orientation panel",
+        "Reports the orientation and zoom state of the brain camera.",
+    ),
+    "userRotation": (
+        "Camera orientation readout",
+        "Current camera orientation expressed in azimuth and elevation degrees.",
+    ),
+}
+
+
+def annotate_widget_accessibility(
+    widget: QtWidgets.QWidget,
+    *,
+    extra: Optional[Mapping[str, _Description]] = None,
+) -> None:
+    """Attach human readable accessibility metadata to *widget* children.
+
+    Parameters
+    ----------
+    widget:
+        The root widget exposing attributes that map to child widgets.
+    extra:
+        Optional mapping of attribute names to ``(name, description)`` tuples.
+        Entries override the default metadata for keys that already exist.
+    """
+
+    descriptions: MutableMapping[str, _Description]
+    descriptions = dict(_DEFAULT_ACCESSIBLE)
+    if extra:
+        descriptions.update(extra)
+
+    for attr, (name, description) in descriptions.items():
+        target = getattr(widget, attr, None)
+        if isinstance(target, QtWidgets.QWidget):
+            if name and not target.accessibleName():
+                target.setAccessibleName(name)
+            if description and not target.accessibleDescription():
+                target.setAccessibleDescription(description)
+
+
+def install_action_shortcuts(
+    widget: QtWidgets.QWidget,
+    *,
+    context: QtCore.Qt.ShortcutContext = QtCore.Qt.ApplicationShortcut,
+    owner: Optional[Mapping[str, QtWidgets.QWidget]] = None,
+) -> List[QtGui.QShortcut]:
+    """Rebind QAction shortcuts to persistent :class:`QShortcut` objects.
+
+    Parameters
+    ----------
+    widget:
+        Widget that owns the actions.  The created shortcuts are stored on
+        this widget via the ``_qt_action_shortcuts`` attribute to keep them
+        alive for the lifetime of the widget.
+    context:
+        Shortcut context to assign to the generated shortcuts.
+    owner:
+        Optional mapping assigning alternative parent widgets for specific
+        actions, keyed by the ``objectName`` of each :class:`QAction`.
+    """
+
+    grouped: MutableMapping[str, List[QtWidgets.QAction]] = defaultdict(list)
+    for action in widget.findChildren(QtGui.QAction):
+        sequence = action.shortcut()
+        # ``QKeySequence`` exposes ``isEmpty`` starting with Qt6.
+        if sequence.isEmpty():  # pragma: no cover - defensive
+            continue
+        text = sequence.toString(QtGui.QKeySequence.PortableText)
+        if not text:
+            continue
+        action.setShortcut(QtGui.QKeySequence())
+        grouped[text].append(action)
+
+    shortcuts: List[QtGui.QShortcut] = []
+    parent_map = owner or {}
+    for text, actions in grouped.items():
+        key_sequence = QtGui.QKeySequence(text)
+        parent = parent_map.get(actions[0].objectName(), widget)
+        shortcut = QtGui.QShortcut(key_sequence, parent)
+        shortcut.setContext(context)
+        for action in actions:
+            shortcut.activated.connect(action.trigger)
+        shortcuts.append(shortcut)
+
+    setattr(widget, "_qt_action_shortcuts", shortcuts)
+    return shortcuts

--- a/visbrain/gui/brain/brain.py
+++ b/visbrain/gui/brain/brain.py
@@ -16,6 +16,7 @@ from .cbar import BrainCbar
 from .user import BrainUserMethods
 from visbrain._pyqt_module import _PyQtModule
 from visbrain.config import PROFILER
+from visbrain.gui._accessibility import install_action_shortcuts
 
 logger = logging.getLogger('visbrain')
 
@@ -109,6 +110,7 @@ class Brain(_PyQtModule, UiInit, UiElements, Visuals, BrainCbar,
         # ====================== Ui interactions ======================
         UiElements.__init__(self)  # GUI interactions
         PROFILER("Ui interactions")
+        self._qt_action_shortcuts = install_action_shortcuts(self)
         self._shpopup.set_shortcuts(self.sh)  # shortcuts dict
 
         # ====================== Cameras ======================

--- a/visbrain/gui/brain/interface/gui/brain_gui.py
+++ b/visbrain/gui/brain/interface/gui/brain_gui.py
@@ -178,6 +178,7 @@ class Ui_MainWindow(object):
         self.verticalLayout_4.setSizeConstraint(QLayout.SetDefaultConstraint)
         self.QuickSettings = QTabWidget(self.q_widget)
         self.QuickSettings.setObjectName(u"QuickSettings")
+        self.QuickSettings.setFocusPolicy(Qt.StrongFocus)
         self.QuickSettings.setMaximumSize(QSize(16777215, 16777215))
         font = QFont()
         font.setBold(False)
@@ -956,6 +957,7 @@ class Ui_MainWindow(object):
         self.verticalLayout_9.setObjectName(u"verticalLayout_9")
         self._source_tab = QTabWidget(self._sources_page)
         self._source_tab.setObjectName(u"_source_tab")
+        self._source_tab.setFocusPolicy(Qt.StrongFocus)
         self.tab_2 = QWidget()
         self.tab_2.setObjectName(u"tab_2")
         self.verticalLayout_24 = QVBoxLayout(self.tab_2)
@@ -2225,6 +2227,7 @@ class Ui_MainWindow(object):
 
         self.progressBar = QProgressBar(self.q_widget)
         self.progressBar.setObjectName(u"progressBar")
+        self.progressBar.setFocusPolicy(Qt.TabFocus)
         self.progressBar.setValue(0)
 
         self.verticalLayout_4.addWidget(self.progressBar)
@@ -2237,6 +2240,7 @@ class Ui_MainWindow(object):
         sizePolicy3.setVerticalStretch(0)
         sizePolicy3.setHeightForWidth(self._objsPage.sizePolicy().hasHeightForWidth())
         self._objsPage.setSizePolicy(sizePolicy3)
+        self._objsPage.setFocusPolicy(Qt.StrongFocus)
         self._BrainPage = QWidget()
         self._BrainPage.setObjectName(u"_BrainPage")
         self.horizontalLayout_7 = QHBoxLayout(self._BrainPage)
@@ -2325,6 +2329,9 @@ class Ui_MainWindow(object):
         self.statusbar = QStatusBar(MainWindow)
         self.statusbar.setObjectName(u"statusbar")
         MainWindow.setStatusBar(self.statusbar)
+        QWidget.setTabOrder(self.QuickSettings, self._obj_type_lst)
+        QWidget.setTabOrder(self._obj_type_lst, self._source_tab)
+        QWidget.setTabOrder(self._source_tab, self.progressBar)
 
         self.menubar.addAction(self.menuFiles.menuAction())
         self.menubar.addAction(self.menuDisplay.menuAction())

--- a/visbrain/gui/brain/interface/gui/brain_gui.ui
+++ b/visbrain/gui/brain/interface/gui/brain_gui.ui
@@ -62,6 +62,9 @@ QLabel { font-size: 10pt; }</string>
         </property>
         <item>
          <widget class="QTabWidget" name="QuickSettings">
+          <property name="focusPolicy">
+           <enum>Qt::StrongFocus</enum>
+          </property>
           <property name="styleSheet">
            <string>QTabWidget::pane { border: 0; }
 QTabBar::tab { padding: 6px 12px; font-size: 10pt; }
@@ -1547,6 +1550,9 @@ name</string>
                <layout class="QVBoxLayout" name="verticalLayout_9">
                 <item>
                  <widget class="QTabWidget" name="_source_tab">
+                  <property name="focusPolicy">
+                   <enum>Qt::StrongFocus</enum>
+                  </property>
                   <property name="currentIndex">
                    <number>2</number>
                   </property>
@@ -3881,6 +3887,9 @@ type</string>
         </item>
         <item>
          <widget class="QProgressBar" name="progressBar">
+          <property name="focusPolicy">
+           <enum>Qt::TabFocus</enum>
+          </property>
           <property name="value">
            <number>0</number>
           </property>
@@ -3894,6 +3903,9 @@ type</string>
          <horstretch>1</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
+       </property>
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
        </property>
        <property name="currentIndex">
         <number>0</number>
@@ -4457,6 +4469,9 @@ type</string>
  </widget>
  <tabstops>
   <tabstop>QuickSettings</tabstop>
+  <tabstop>_obj_type_lst</tabstop>
+  <tabstop>_source_tab</tabstop>
+  <tabstop>progressBar</tabstop>
  </tabstops>
  <resources />
  <connections />

--- a/visbrain/gui/brain/interface/ui_init.py
+++ b/visbrain/gui/brain/interface/ui_init.py
@@ -6,13 +6,14 @@ Grouped components :
     * User shortcuts
 """
 
-from visbrain.qt import QtWidgets
+from visbrain.qt import QtCore, QtWidgets
 
 from vispy import app
 from vispy.scene.cameras import TurntableCamera
 
 from .gui import Ui_MainWindow
 from visbrain.objects import VisbrainCanvas
+from visbrain.gui._accessibility import annotate_widget_accessibility
 
 
 class BrainShortcuts(object):
@@ -123,6 +124,22 @@ class UiInit(QtWidgets.QMainWindow, Ui_MainWindow, app.Canvas, BrainShortcuts):
         # Create the main window :
         super(UiInit, self).__init__(None)
         self.setupUi(self)
+        self.setAccessibleName("Brain window")
+        self.setAccessibleDescription(
+            "Interactive 3D brain visualization with keyboard accessible controls."
+        )
+        annotate_widget_accessibility(
+            self,
+            extra={
+                "_objsPage": (
+                    "Visualization panels",
+                    (
+                        "Stacked configuration panels controlling brain, sources, "
+                        "and derived visualizations."
+                    ),
+                ),
+            },
+        )
 
         #######################################################################
         #                            BRAIN CANVAS
@@ -132,12 +149,22 @@ class UiInit(QtWidgets.QMainWindow, Ui_MainWindow, app.Canvas, BrainShortcuts):
         self.view = VisbrainCanvas(name='MainCanvas', camera=self._camera,
                                    **cdict)
         self.vBrain.addWidget(self.view.canvas.native)
+        self.view.canvas.native.setFocusPolicy(QtCore.Qt.StrongFocus)
+        self.view.canvas.native.setAccessibleName("Brain canvas")
+        self.view.canvas.native.setAccessibleDescription(
+            "Primary 3D canvas displaying the brain surface and overlays."
+        )
 
         #######################################################################
         #                         CROSS-SECTIONS CANVAS
         #######################################################################
         self._csView = VisbrainCanvas(name='SplittedCrossSections', **cdict)
         self._axialLayout.addWidget(self._csView.canvas.native)
+        self._csView.canvas.native.setFocusPolicy(QtCore.Qt.StrongFocus)
+        self._csView.canvas.native.setAccessibleName("Cross-sections canvas")
+        self._csView.canvas.native.setAccessibleDescription(
+            "Orthogonal cross-section views linked to the main brain canvas."
+        )
 
         # Initialize shortcuts :
         BrainShortcuts.__init__(self, self.view.canvas)

--- a/visbrain/gui/signal/interface/gui/signal_gui.py
+++ b/visbrain/gui/signal/interface/gui/signal_gui.py
@@ -227,6 +227,7 @@ class Ui_MainWindow(object):
         self.verticalLayout_4.setContentsMargins(0, 0, 0, 0)
         self.QuickSettings = QTabWidget(self.q_widget)
         self.QuickSettings.setObjectName(u"QuickSettings")
+        self.QuickSettings.setFocusPolicy(Qt.StrongFocus)
         self.QuickSettings.setMaximumSize(QSize(16777215, 16777215))
         self.QuickSettings.setAutoFillBackground(False)
         self.QuickSettings.setTabShape(QTabWidget.Rounded)
@@ -1716,6 +1717,8 @@ class Ui_MainWindow(object):
         self.statusbar = QStatusBar(MainWindow)
         self.statusbar.setObjectName(u"statusbar")
         MainWindow.setStatusBar(self.statusbar)
+        QWidget.setTabOrder(self.QuickSettings, self._sig_title)
+        QWidget.setTabOrder(self._sig_title, self._sig_form)
 
         self.menubar.addAction(self.menuFile.menuAction())
         self.menubar.addAction(self.menuDisplay.menuAction())

--- a/visbrain/gui/signal/interface/gui/signal_gui.ui
+++ b/visbrain/gui/signal/interface/gui/signal_gui.ui
@@ -87,6 +87,9 @@
            </property>
            <item>
             <widget class="QTabWidget" name="QuickSettings">
+             <property name="focusPolicy">
+              <enum>Qt::StrongFocus</enum>
+             </property>
              <property name="maximumSize">
               <size>
                <width>16777215</width>
@@ -3191,12 +3194,17 @@ type</string>
     <string>Annotations</string>
    </property>
   </action>
-  <action name="loadAnnotations">
-   <property name="text">
-    <string>Annotations</string>
-   </property>
-  </action>
- </widget>
+ <action name="loadAnnotations">
+  <property name="text">
+   <string>Annotations</string>
+  </property>
+ </action>
+</widget>
+ <tabstops>
+  <tabstop>QuickSettings</tabstop>
+  <tabstop>_sig_title</tabstop>
+  <tabstop>_sig_form</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/visbrain/gui/signal/signal.py
+++ b/visbrain/gui/signal/signal.py
@@ -9,6 +9,7 @@ from visbrain.utils import (safely_set_cbox, color2tuple, color2vb, mpl_cmap,
 from visbrain.io import write_fig_canvas
 from visbrain._pyqt_module import _PyQtModule
 # get_screen_size
+from visbrain.gui._accessibility import install_action_shortcuts
 
 
 __all__ = ('Signal')
@@ -239,6 +240,7 @@ class Signal(_PyQtModule, UiInit, UiElements, Visuals):
 
         # ==================== USER <-> GUI ====================
         UiElements.__init__(self, **kwargs)
+        self._qt_action_shortcuts = install_action_shortcuts(self)
 
         # Keep the canvas cameras in sync when the visibility of their
         # container widgets changes.

--- a/visbrain/gui/signal/ui_elements/ui_init.py
+++ b/visbrain/gui/signal/ui_elements/ui_init.py
@@ -2,13 +2,14 @@
 import numpy as np
 from warnings import warn
 
-from visbrain.qt import QtWidgets
+from visbrain.qt import QtCore, QtWidgets
 
 import vispy.scene.cameras as viscam
 from vispy import app
 
 from ..interface.gui import Ui_MainWindow
 from visbrain.objects import VisbrainCanvas
+from visbrain.gui._accessibility import annotate_widget_accessibility
 
 
 class GridShortcuts(object):
@@ -135,6 +136,22 @@ class UiInit(QtWidgets.QMainWindow, Ui_MainWindow, app.Canvas):
         # Create the main window :
         super(UiInit, self).__init__(None)
         self.setupUi(self)
+        self.setAccessibleName("Signal window")
+        self.setAccessibleDescription(
+            "Time-series exploration interface with keyboard navigable controls."
+        )
+        annotate_widget_accessibility(
+            self,
+            extra={
+                "_sig_title": (
+                    "Signal title",
+                    (
+                        "Text field defining the title displayed above the active "
+                        "signal view."
+                    ),
+                ),
+            },
+        )
 
         # Cameras :
         grid_rect = (0, 0, 1, 1)
@@ -156,6 +173,27 @@ class UiInit(QtWidgets.QMainWindow, Ui_MainWindow, app.Canvas):
         # Add canvas to layout :
         self._GridLayout.addWidget(self._grid_canvas.canvas.native)
         self._SignalLayout.addWidget(self._signal_canvas.canvas.native)
+        for widget, name, description in (
+            (
+                self._grid_canvas.canvas.native,
+                "Signal grid canvas",
+                (
+                    "Displays multiple channels in a grid layout for overview "
+                    "exploration."
+                ),
+            ),
+            (
+                self._signal_canvas.canvas.native,
+                "Signal detail canvas",
+                (
+                    "Single-channel visualization used for detailed inspection "
+                    "and annotation."
+                ),
+            ),
+        ):
+            widget.setFocusPolicy(QtCore.Qt.StrongFocus)
+            widget.setAccessibleName(name)
+            widget.setAccessibleDescription(description)
 
         # Initialize shortcuts :
         GridShortcuts.__init__(self, self._grid_canvas.canvas)

--- a/visbrain/gui/sleep/interface/gui/sleep_gui.py
+++ b/visbrain/gui/sleep/interface/gui/sleep_gui.py
@@ -201,6 +201,7 @@ class Ui_MainWindow(object):
         self.verticalLayout_4.setContentsMargins(0, 0, 0, 0)
         self.QuickSettings = QTabWidget(self.q_widget)
         self.QuickSettings.setObjectName(u"QuickSettings")
+        self.QuickSettings.setFocusPolicy(Qt.StrongFocus)
         self.QuickSettings.setMaximumSize(QSize(16777215, 16777215))
         self.QuickSettings.setAutoFillBackground(False)
         self.QuickSettings.setTabShape(QTabWidget.Rounded)
@@ -249,6 +250,7 @@ class Ui_MainWindow(object):
 
         self._stacked_panels = QStackedWidget(self.q_Panels)
         self._stacked_panels.setObjectName(u"_stacked_panels")
+        self._stacked_panels.setFocusPolicy(Qt.StrongFocus)
         self._stacked_panels.setFrameShape(QFrame.NoFrame)
         self._channels_page = QWidget()
         self._channels_page.setObjectName(u"_channels_page")
@@ -1064,6 +1066,7 @@ class Ui_MainWindow(object):
 
         self._stacked_tools = QStackedWidget(self.q_Tools)
         self._stacked_tools.setObjectName(u"_stacked_tools")
+        self._stacked_tools.setFocusPolicy(Qt.StrongFocus)
         self._sigproc_page = QWidget()
         self._sigproc_page.setObjectName(u"_sigproc_page")
         self.verticalLayout_25 = QVBoxLayout(self._sigproc_page)
@@ -1695,6 +1698,7 @@ class Ui_MainWindow(object):
 
         self._stacked_detections = QStackedWidget(self.groupBox_2)
         self._stacked_detections.setObjectName(u"_stacked_detections")
+        self._stacked_detections.setFocusPolicy(Qt.StrongFocus)
         sizePolicy4 = QSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Maximum)
         sizePolicy4.setHorizontalStretch(0)
         sizePolicy4.setVerticalStretch(0)
@@ -2673,6 +2677,9 @@ class Ui_MainWindow(object):
         self.statusbar = QStatusBar(MainWindow)
         self.statusbar.setObjectName(u"statusbar")
         MainWindow.setStatusBar(self.statusbar)
+        QWidget.setTabOrder(self.QuickSettings, self._stacked_panels)
+        QWidget.setTabOrder(self._stacked_panels, self._stacked_tools)
+        QWidget.setTabOrder(self._stacked_tools, self._stacked_detections)
 
         self.menubar.addAction(self.menuFiles.menuAction())
         self.menubar.addAction(self.menuDisplay.menuAction())

--- a/visbrain/gui/sleep/interface/gui/sleep_gui.ui
+++ b/visbrain/gui/sleep/interface/gui/sleep_gui.ui
@@ -87,6 +87,9 @@
         </property>
         <item>
          <widget class="QTabWidget" name="QuickSettings">
+          <property name="focusPolicy">
+           <enum>Qt::StrongFocus</enum>
+          </property>
           <property name="maximumSize">
            <size>
             <width>16777215</width>
@@ -193,6 +196,9 @@ type</string>
             </item>
             <item>
              <widget class="QStackedWidget" name="_stacked_panels">
+              <property name="focusPolicy">
+               <enum>Qt::StrongFocus</enum>
+              </property>
               <property name="frameShape">
                <enum>QFrame::NoFrame</enum>
               </property>
@@ -1769,6 +1775,9 @@ type</string>
             </item>
             <item>
              <widget class="QStackedWidget" name="_stacked_tools">
+              <property name="focusPolicy">
+               <enum>Qt::StrongFocus</enum>
+              </property>
               <property name="currentIndex">
                <number>1</number>
               </property>
@@ -2977,6 +2986,9 @@ on</string>
                    </item>
                    <item>
                     <widget class="QStackedWidget" name="_stacked_detections">
+                     <property name="focusPolicy">
+                      <enum>Qt::StrongFocus</enum>
+                     </property>
                      <property name="sizePolicy">
                       <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
                        <horstretch>0</horstretch>
@@ -5277,15 +5289,21 @@ display</string>
     <string>Annotations</string>
    </property>
   </action>
-  <action name="menuSaveScreenshot">
-   <property name="text">
-    <string>Screenshot</string>
-   </property>
-   <property name="shortcut">
-    <string>Ctrl+N</string>
-   </property>
-  </action>
- </widget>
+ <action name="menuSaveScreenshot">
+  <property name="text">
+   <string>Screenshot</string>
+  </property>
+  <property name="shortcut">
+   <string>Ctrl+N</string>
+  </property>
+ </action>
+</widget>
+ <tabstops>
+  <tabstop>QuickSettings</tabstop>
+  <tabstop>_stacked_panels</tabstop>
+  <tabstop>_stacked_tools</tabstop>
+  <tabstop>_stacked_detections</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/visbrain/gui/sleep/interface/ui_elements/ui_panels.py
+++ b/visbrain/gui/sleep/interface/ui_elements/ui_panels.py
@@ -70,6 +70,11 @@ class UiPanels(object):
         self._SpecW, self._SpecLayout = self._create_compatible_w("SpecW",
                                                                   "SpecL")
         self._SpecLayout.addWidget(self._specCanvas.canvas.native)
+        self._specCanvas.canvas.native.setFocusPolicy(QtCore.Qt.StrongFocus)
+        self._specCanvas.canvas.native.setAccessibleName("Spectrogram canvas")
+        self._specCanvas.canvas.native.setAccessibleDescription(
+            "Displays the spectrogram for the selected channel."
+        )
         self._chanGrid.addWidget(self._SpecW, len(self) + 1, 1, 1, 1)
         # Add label :
         self._specLabel = QtWidgets.QLabel(self.centralwidget)
@@ -107,6 +112,11 @@ class UiPanels(object):
                                      fcn=[self.on_mouse_wheel], use_pad=True)
         self._HypW, self._HypLayout = self._create_compatible_w("HypW", "HypL")
         self._HypLayout.addWidget(self._hypCanvas.canvas.native)
+        self._hypCanvas.canvas.native.setFocusPolicy(QtCore.Qt.StrongFocus)
+        self._hypCanvas.canvas.native.setAccessibleName("Hypnogram canvas")
+        self._hypCanvas.canvas.native.setAccessibleDescription(
+            "Shows the sleep stage hypnogram with keyboard accessible controls."
+        )
         self._chanGrid.addWidget(self._HypW, len(self) + 2, 1, 1, 1)
         # Add label :
         self._hypLabel = QtWidgets.QWidget()
@@ -132,6 +142,11 @@ class UiPanels(object):
         # Main canvas for the spectrogram :
         self._topoCanvas = AxisCanvas(axis=False, name='Topoplot')
         self._topoLayout.addWidget(self._topoCanvas.canvas.native)
+        self._topoCanvas.canvas.native.setFocusPolicy(QtCore.Qt.StrongFocus)
+        self._topoCanvas.canvas.native.setAccessibleName("Topography canvas")
+        self._topoCanvas.canvas.native.setAccessibleDescription(
+            "Displays sensor topographies for the current selection."
+        )
         self._topoW.setVisible(False)
         self._PanTopoCmin.setValue(-.5)
         self._PanTopoCmax.setValue(.5)
@@ -161,6 +176,11 @@ class UiPanels(object):
         self._TimeAxisW, self._TimeLayout = self._create_compatible_w("TimeW",
                                                                       "TimeL")
         self._TimeLayout.addWidget(self._TimeAxis.canvas.native)
+        self._TimeAxis.canvas.native.setFocusPolicy(QtCore.Qt.StrongFocus)
+        self._TimeAxis.canvas.native.setAccessibleName("Time axis canvas")
+        self._TimeAxis.canvas.native.setAccessibleDescription(
+            "Timeline showing the current window and annotated events."
+        )
         self._TimeAxisW.setMaximumHeight(400)
         self._TimeAxisW.setMinimumHeight(50)
         self._chanGrid.addWidget(self._TimeAxisW, len(self) + 3, 1, 1, 1)
@@ -217,6 +237,7 @@ class UiPanels(object):
                                         QtWidgets.QSizePolicy.Minimum)
 
         # Loop over channels :
+        self._channel_shortcuts = []
         for i, k in enumerate(self._channels):
             # ============ CHECKBOX ============
             # ----- MAIN CHECKBOX -----
@@ -225,7 +246,10 @@ class UiPanels(object):
             # Name checkbox with channel name :
             self._chanChecks[i].setObjectName(_fromUtf8("_CheckChan" + k))
             self._chanChecks[i].setText(k)
-            self._chanChecks[i].setShortcut("Ctrl+" + str(i))
+            shortcut = QtGui.QShortcut(QtGui.QKeySequence(f"Ctrl+{i}"), self)
+            shortcut.setContext(QtCore.Qt.ApplicationShortcut)
+            shortcut.activated.connect(self._chanChecks[i].toggle)
+            self._channel_shortcuts.append(shortcut)
             # Add checkbox to the grid :
             self._PanChanLay.addWidget(self._chanChecks[i], i, 0, 1, 1)
             # Connect with the function :
@@ -277,7 +301,13 @@ class UiPanels(object):
                                              name='Canvas_' + k,
                                              fcn=[self.on_mouse_wheel])
             # Add the canvas to the layout :
-            self._chanLayout[i].addWidget(self._chanCanvas[i].canvas.native)
+            canvas_widget = self._chanCanvas[i].canvas.native
+            self._chanLayout[i].addWidget(canvas_widget)
+            canvas_widget.setFocusPolicy(QtCore.Qt.StrongFocus)
+            canvas_widget.setAccessibleName(f"Channel {k} canvas")
+            canvas_widget.setAccessibleDescription(
+                f"Displays the time-series waveform for channel {k}."
+            )
 
         self._PanChanLay.addItem(vspacer, i + 1, 0, 1, 1)
         self._chanGrid.addItem(hspacer, i + 4, 1, 1, 1)

--- a/visbrain/gui/sleep/interface/ui_init.py
+++ b/visbrain/gui/sleep/interface/ui_init.py
@@ -14,6 +14,7 @@ import vispy.visuals.transforms as vist
 from ..visuals.marker import Markers
 from .gui import Ui_MainWindow
 from visbrain.utils import color2vb
+from visbrain.gui._accessibility import annotate_widget_accessibility
 
 
 class UiInit(QtWidgets.QMainWindow, Ui_MainWindow, app.Canvas):
@@ -24,6 +25,14 @@ class UiInit(QtWidgets.QMainWindow, Ui_MainWindow, app.Canvas):
         # Create the main window :
         super(UiInit, self).__init__(None)
         self.setupUi(self)
+        self.setAccessibleName("Sleep window")
+        self.setAccessibleDescription(
+            (
+                "Sleep scoring workspace with stacked panels for channels, tools, "
+                "and detections."
+            )
+        )
+        annotate_widget_accessibility(self)
 
 
 class TimeAxis(object):

--- a/visbrain/gui/sleep/sleep.py
+++ b/visbrain/gui/sleep/sleep.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 from visbrain._pyqt_module import _PyQtModule
 from visbrain.config import PROFILER
+from visbrain.gui._accessibility import install_action_shortcuts
 
 from .controller import SleepController
 from .model import SleepDataset
@@ -75,6 +76,7 @@ class Sleep(_PyQtModule):
             config_file=config_file,
         )
         self._apply_theme()
+        install_action_shortcuts(self._view)
 
     # ------------------------------------------------------------------
     # Composition accessors

--- a/visbrain/gui/tests/test_accessibility.py
+++ b/visbrain/gui/tests/test_accessibility.py
@@ -1,0 +1,117 @@
+"""Accessibility smoke tests for the main Qt GUIs."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from visbrain.gui.brain import Brain
+from visbrain.gui.signal import Signal
+from visbrain.gui.sleep import Sleep
+from visbrain.qt import QtCore
+
+
+@pytest.fixture
+def brain_app(qtbot):
+    brain = Brain(bgcolor='black', verbose=None)
+    qtbot.addWidget(brain)
+    brain.show()
+    qtbot.waitUntil(lambda: brain.isVisible())
+    yield brain
+    brain.close()
+
+
+@pytest.fixture
+def signal_app(qtbot):
+    data = np.zeros((2, 64), dtype=np.float32)
+    time = np.linspace(0.0, 1.0, data.shape[-1], dtype=np.float32)
+    signal = Signal(data=data, time=time, sf=1.0, verbose=None)
+    qtbot.addWidget(signal)
+    signal.show()
+    qtbot.waitUntil(lambda: signal.isVisible())
+    yield signal
+    signal.close()
+
+
+@pytest.fixture
+def sleep_app(qtbot):
+    data = np.zeros((1, 200), dtype=np.float32)
+    hypno = np.zeros(200, dtype=np.int32)
+    sleep = Sleep(data=data, sf=1.0, hypno=hypno, channels=['Cz'])
+    view = sleep.view
+    qtbot.addWidget(view)
+    view.show()
+    qtbot.waitUntil(lambda: view.isVisible())
+    yield sleep
+    view.close()
+
+
+@pytest.mark.parametrize(
+    "shortcut_key",
+    [QtCore.Qt.Key_D],
+    ids=lambda key: f"Ctrl+{chr(key)}",
+)
+def test_brain_focus_and_shortcut(brain_app, qtbot, shortcut_key):
+    brain = brain_app
+    quick = brain.QuickSettings
+    assert quick.accessibleName()
+    assert quick.accessibleDescription()
+    quick.setFocus()
+    qtbot.waitUntil(quick.hasFocus)
+
+    qtbot.keyClick(brain, QtCore.Qt.Key_Tab)
+    assert brain.focusWidget() is brain._obj_type_lst
+
+    initially_visible = brain.q_widget.isVisible()
+    qtbot.keyClick(brain, shortcut_key, modifier=QtCore.Qt.ControlModifier)
+    qtbot.waitUntil(lambda: brain.q_widget.isVisible() is not initially_visible)
+    qtbot.keyClick(brain, shortcut_key, modifier=QtCore.Qt.ControlModifier)
+    qtbot.waitUntil(lambda: brain.q_widget.isVisible() is initially_visible)
+
+    assert brain.statusbar.accessibleDescription()
+    assert brain.userRotation.accessibleDescription()
+    assert brain.view.canvas.native.accessibleName()
+    assert brain._csView.canvas.native.accessibleName()
+
+
+def test_signal_focus_and_shortcut(signal_app, qtbot):
+    signal = signal_app
+    quick = signal.QuickSettings
+    assert quick.accessibleName()
+    quick.setFocus()
+    qtbot.waitUntil(quick.hasFocus)
+
+    qtbot.keyClick(signal, QtCore.Qt.Key_Tab)
+    assert signal.focusWidget() is signal._sig_title
+
+    initially_visible = signal.q_widget.isVisible()
+    qtbot.keyClick(signal, QtCore.Qt.Key_D, modifier=QtCore.Qt.ControlModifier)
+    qtbot.waitUntil(lambda: signal.q_widget.isVisible() is not initially_visible)
+    qtbot.keyClick(signal, QtCore.Qt.Key_D, modifier=QtCore.Qt.ControlModifier)
+    qtbot.waitUntil(lambda: signal.q_widget.isVisible() is initially_visible)
+
+    assert signal._grid_canvas.canvas.native.accessibleName()
+    assert signal._signal_canvas.canvas.native.accessibleName()
+
+
+def test_sleep_focus_and_shortcut(sleep_app, qtbot):
+    sleep = sleep_app
+    view = sleep.view
+    quick = view.QuickSettings
+    assert quick.accessibleName()
+    quick.setFocus()
+    qtbot.waitUntil(quick.hasFocus)
+
+    qtbot.keyClick(view, QtCore.Qt.Key_Tab)
+    assert view.focusWidget() is view._stacked_panels
+
+    initially_visible = view.q_widget.isVisible()
+    qtbot.keyClick(view, QtCore.Qt.Key_D, modifier=QtCore.Qt.ControlModifier)
+    qtbot.waitUntil(lambda: view.q_widget.isVisible() is not initially_visible)
+    qtbot.keyClick(view, QtCore.Qt.Key_D, modifier=QtCore.Qt.ControlModifier)
+    qtbot.waitUntil(lambda: view.q_widget.isVisible() is initially_visible)
+
+    assert view._specCanvas.canvas.native.accessibleName()
+    assert view._hypCanvas.canvas.native.accessibleName()
+    assert view._topoCanvas.canvas.native.accessibleName()
+    assert view._TimeAxis.canvas.native.accessibleName()


### PR DESCRIPTION
## Summary
- add a reusable accessibility helper to attach descriptive metadata and persistent Qt shortcuts
- update the brain, signal and sleep interfaces to set focus policies, accessible descriptions and store shortcut bindings
- add pytest-qt smoke tests that exercise keyboard navigation and shortcut toggles across the main GUIs

## Testing
- `make flake`
- `pytest visbrain/gui/tests -k accessibility` *(fails: missing libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68d05c941c388328bac9becb9bef7e87