### PR TITLE
docs: document harness use without committing pngs

### DIFF
--- a/docs/brain.rst
+++ b/docs/brain.rst
@@ -128,6 +128,39 @@ Settings panel tabs
 * Connect tab (*connectivity settings*)
 * Cbar tab (*colorbar properties of the selected object*)
 
+Themes and accessibility
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The :menuselection:`Display --> Theme` submenu exposes the built-in
+``Dark`` and ``Light`` palettes.  Switching themes updates the global Qt
+palette so menus, dialogs and canvases immediately pick up the new colors.
+Visbrain remembers the last selection, allowing contributors to document a
+consistent look-and-feel across sessions or revert to high-contrast defaults
+before screen captures.
+
+.. note::
+   Refresh theme previews locally with the Task 8 screenshot harness described
+   in :doc:`modernization/phase-3`.  The capture script stores PNG assets under
+   ``docs/_static/brain/`` for reference while drafting documentation, but the
+   generated files are not committed to the repository.
+
+Keyboard navigation and accessibility hints
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+All primary canvases request ``StrongFocus`` so keyboard users can reach them
+with :kbd:`Tab`/:kbd:`Shift` + :kbd:`Tab`.  Global shortcuts such as
+:kbd:`Ctrl+D` (toggle quick settings), :kbd:`Ctrl+N` (screenshot) and
+:kbd:`Ctrl+E` (open the documentation) remain active even when a VisPy canvas is
+focused thanks to the action rebinding performed during initialization.  The
+:menuselection:`Help --> Shortcuts` entry—or the :kbd:`Ctrl+T` accelerator—opens
+an accessible table describing the available key sequences and their effects.
+
+.. note::
+   Capture the shortcuts helper overlay through the same Task 8 harness when
+   preparing release notes or tutorials so the keyboard table stays in sync with
+   the shipped GUI.  Like the theme previews, keep the exported PNGs out of the
+   tracked sources.
+
 .. _brainshortcuts:
 
 Shortcuts

--- a/docs/example_to_thumbnails.py
+++ b/docs/example_to_thumbnails.py
@@ -1,11 +1,24 @@
 import os
 import logging
 import fileinput
+
 from sphinx_gallery.gen_rst import scale_image
-from sphinx_gallery import sphinx_compatibility
+
+try:
+    from sphinx_gallery import sphinx_compatibility
+except ImportError:  # sphinx-gallery 0.15 removed the helper module
+    sphinx_compatibility = None  # type: ignore[assignment]
 
 
-logger = sphinx_compatibility.getLogger('sphinx')
+if sphinx_compatibility is not None:
+    logger = sphinx_compatibility.getLogger('sphinx')
+else:
+    logger = logging.getLogger('sphinx-gallery')
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter('%(levelname)s: %(message)s'))
+        logger.addHandler(handler)
+
 logger.setLevel(logging.INFO)
 logger.info("generating thumbnails using example images...")
 # logger.warning(colorize('test', 'darkred'))

--- a/docs/figure.rst
+++ b/docs/figure.rst
@@ -77,7 +77,7 @@ Example
    Code above : four exported figures from the Brain module are aranged in a (2, 2) grid. Then, some have a colorbar, xlabel, ylabel. Finally, there is two shared colorbars.
 
 
-.. include:: generated/visbrain.Figure.examples
+.. include:: generated/visbrain.gui.Figure.examples
 
 .. raw:: html
 

--- a/docs/modernization/phase-3.rst
+++ b/docs/modernization/phase-3.rst
@@ -62,6 +62,11 @@ Rollout and testing
 * Refresh contributor guides once the regenerated stack lands, highlighting the
   PySide6 workflow, the supported Python/OS matrix and the VisPy baseline so
   developers verify patches on the official matrix before submitting changes.
+* Extend the user guides with runtime theme switching, keyboard shortcut
+  overlays and accessibility affordances.  Updated figures should be captured
+  through the Task 8 screenshot harness so documentation reflects the
+  high-contrast palettes and navigation hints available in the regenerated
+  widgets, while keeping the generated PNG assets out of version control.
 
 Supporting inventory
 --------------------

--- a/docs/sleep.rst
+++ b/docs/sleep.rst
@@ -145,6 +145,36 @@ The contextual menu allows to perform several functions such as the loading and 
 **Settings panel** :
 The setting panels is where most of the (advanced) functions of the software are! Among other things, you can control which channel to display, adjust the amplitudes, customize the spectrogram and hypnogram, compute the duration of each sleep stage, add annotations to the recording, and perform a bunch of semi-automatic detection (spindles, K-complexes...). See the section :ref:`sleep_settings_panel` for a description of each tab.
 
+Themes and accessibility
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Sleep ships with the same runtime theme manager as the Brain module.  Use the
+:menuselection:`Display --> Theme` submenu to toggle between the high contrast
+``Dark`` palette and the presentation-friendly ``Light`` variant; Visbrain
+persists the preference between launches so workshop demos and automated screen
+captures stay consistent.
+
+.. note::
+   Generate theme previews with the Task 8 screenshot harness referenced in
+   :doc:`modernization/phase-3` when preparing documentation updates.  The
+   captures land in ``docs/_static/brain/`` during the build step so writers can
+   embed or review them locally, but the PNG files stay out of version control.
+
+All canvases (channel grid, spectrogram, hypnogram, topo map and the global time
+axis) request keyboard focus and expose accessible names/descriptions, allowing
+screen readers and :kbd:`Tab` navigation to reference the active visualization.
+Global shortcuts remain active regardless of focus—for example :kbd:`Ctrl+D`
+toggles the settings panel, :kbd:`Ctrl+S` saves the hypnogram and :kbd:`Ctrl+T`
+opens the keyboard reference panel.  The :menuselection:`Help --> Shortcuts`
+entry uses the same accessible table as the Brain module and surfaces the
+scoring keys (:kbd:`1`/ :kbd:`2`/ :kbd:`3`, :kbd:`R`, etc.) alongside utility
+actions.
+
+.. note::
+   Use the same Task 8 harness to refresh the shortcuts helper overlay for Sleep
+   when preparing tutorials or changelogs.  Share the resulting PNGs alongside
+   release artifacts instead of checking them into the repository.
+
 .. _sleep_settings_panel:
 
 Settings panel tabs
@@ -612,22 +642,20 @@ After pressing one of those keys, the software will score accordingly the curren
 
 The software supports two modes of scoring, to allow scoring of both human or animal data:
 
-* **In "locked" mode (option "Lock scoring to display" checked), the "scoring
-window" is always equal to the display window**, and pressing a key will score
-the whole displayed epoch. By default in this mode, the slider step is equal
-to the duration of the displayed epoch. This mode is useful for scoring human datasets.
+* **Locked mode** (when :menuselection:`Display --> Lock scoring to display` is
+  enabled) keeps the scoring window equal to the display window, so pressing a
+  key scores the entire visible epoch. The slider step defaults to the display
+  duration, mirroring manual workflows for human datasets.
 
-* **In "unlocked" mode (option "Lock scoring to display" unchecked), the "scoring
-window" is independent from the display window**, letting the user score short
-epochs while visualizing the data around the scored epochs. The limits of the
-scoring window are indicated by vertical bars on the channel plots (which can be
-hidden by toggling the "Display scoring window" option). By entering the "Zoom"
-mode ("Zoom" in the menu options or shortcut "z"), the user can also zoom into
-the hypnogram to visualize the stages within the whole displayed epoch, and thus
-around the scored epoch. This is typically useful for scoring animal datasets.
-By default in this mode, the slider step is equal to the duration of the scoring
-window. The software will switch automatically to the "unlocked" mode when
-explicitly changing the scoring window size. 
+* **Unlocked mode** (when :menuselection:`Display --> Lock scoring to display`
+  is cleared) lets the scoring window move independently from the display
+  window, allowing you to label short epochs while retaining surrounding
+  context. Vertical bars on the channel plots mark the scoring window and can be
+  toggled via the :menuselection:`Display scoring window` action. The
+  :menuselection:`Display --> Zoom` tool (or :kbd:`Z`) refines the hypnogram view
+  around the scored epoch—handy for animal datasets. In this mode the slider
+  step follows the scoring window duration, and adjusting the window size
+  automatically disables the locked mode.
 
 
 .. warning::
@@ -635,15 +663,18 @@ explicitly changing the scoring window size.
 
 .. figure::  _static/sleep/sleep_scoring_locked.png
    :align:   center
-   Score the whole displayed epoch
+
+   Score the whole displayed epoch.
 
 .. figure::  _static/sleep/sleep_scoring_unlocked.png
    :align:   center
-   Score the epoch within the centered "scoring window"
+
+   Score the epoch within the centered "scoring window".
 
 .. figure::  _static/sleep/sleep_scoring_unlocked_zoom.png
    :align:   center
-   Use the "Zoom" mode to visualize the hypnogram around the scored epoch
+
+   Use the "Zoom" mode to visualize the hypnogram around the scored epoch.
 
 .. ----------------------------------------------------------------------------
 ..                              DETECTIONS


### PR DESCRIPTION
## Summary
- remove the Task 8 harness PNG assets from `docs/_static/brain` so the documentation build no longer relies on binary files in the repository
- note in the Brain and Sleep guides that contributors should regenerate theme and shortcuts captures locally with Task 8 without committing the PNGs
- update the Phase 3 modernization plan to reiterate that harness-generated images stay out of version control

## Testing
- `PATH="/root/.pyenv/versions/3.12.10/bin:$PATH" make flake`
- `PYTHONPATH="/workspace/visbrain" PATH="/root/.pyenv/versions/3.12.10/bin:$PATH" make -C docs html`
- `PATH="/root/.pyenv/versions/3.12.10/bin:$PATH" pytest visbrain/gui/signal/tests/test_signal.py` *(fails: Qt-based GUI test aborts during import)*

------
https://chatgpt.com/codex/tasks/task_e_68d0622fe4888328b81215a2dbd0da02