### PR TITLE
docs: clarify Qt UI regeneration coverage

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -4,15 +4,16 @@ Development workflow
 Qt interface regeneration
 -------------------------
 
-The Brain and Sleep GUIs rely on Qt Designer files stored under
-``visbrain/gui/*/interface``. After adjusting a ``.ui`` file, regenerate the
-corresponding Python module with::
+The Brain, Sleep, Signal, and Figure GUIs rely on Qt Designer assets stored
+under ``visbrain/gui/*/interface``.  After adjusting a ``.ui`` file in any of
+those modules, regenerate the corresponding Python wrappers with::
 
    make qt-ui
 
 The command wraps :mod:`PySide6`'s ``pyside6-uic`` and ``pyside6-rcc`` tools and
-updates every generated module in place.  Continuous integration now executes
-``python tools/generate_qt_ui.py --check`` as part of :command:`make flake`, so
-linting fails whenever committed artifacts are stale.  Run ``make qt-ui`` after
-editing Qt resources and re-run ``make flake`` to verify that everything is
-up to date before sending a pull request.
+touches every generated module under ``visbrain/gui/*/interface``.  Continuous
+integration now executes ``python tools/generate_qt_ui.py --check`` as part of
+:command:`make flake`, so linting fails whenever committed artifacts are
+stale.  Run ``make qt-ui`` immediately after editing Qt resources and then
+re-run ``make flake`` to verify that everything is up to date before sending a
+pull request.


### PR DESCRIPTION
## Summary
- clarify the Qt UI regeneration instructions to list the Brain, Sleep, Signal, and Figure modules
- explain that `make qt-ui` refreshes every generated interface module and reiterate running it after editing Qt assets

## Testing
- make -C docs html

------
https://chatgpt.com/codex/tasks/task_e_68d11f12692083289c072e02ed6e0308