### PR TITLE
Update screenshot dialog UI and regenerate PySide artifacts

### DIFF
--- a/tools/generate_qt_ui.py
+++ b/tools/generate_qt_ui.py
@@ -20,12 +20,14 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 GUI_ROOT = REPO_ROOT / "visbrain" / "gui"
 INTERFACE_TOKEN = "interface"
 VISUALS_ROOT = REPO_ROOT / "visbrain" / "visuals"
+UTILS_GUI_ROOT = REPO_ROOT / "visbrain" / "utils" / "gui"
 
 # Additional Qt Designer search roots.  Each entry provides a directory and an
 # optional predicate used to filter rglob results.
 QT_SEARCH_SCOPES: tuple[tuple[Path, Callable[[Path], bool]], ...] = (
     (GUI_ROOT, lambda path: INTERFACE_TOKEN in path.parts),
     (VISUALS_ROOT, lambda _path: True),
+    (UTILS_GUI_ROOT, lambda _path: True),
 )
 
 
@@ -103,14 +105,20 @@ def _normalize_ui_imports(content: str) -> str:
     return header + "from visbrain.qt import QtCore, QtGui, QtWidgets\n\n" + body
 
 
+NORMALIZE_IMPORT_ROOTS = (VISUALS_ROOT, UTILS_GUI_ROOT)
+
+
 def _should_normalize(ui_file: Path) -> bool:
     """Return ``True`` when *ui_file* should use :mod:`visbrain.qt` imports."""
 
-    try:
-        ui_file.relative_to(VISUALS_ROOT)
-    except ValueError:
-        return False
-    return True
+    for root in NORMALIZE_IMPORT_ROOTS:
+        try:
+            ui_file.relative_to(root)
+        except ValueError:
+            continue
+        else:
+            return True
+    return False
 
 
 def _run_generator(command: list[str]) -> str:

--- a/visbrain/utils/gui/screenshot_gui.py
+++ b/visbrain/utils/gui/screenshot_gui.py
@@ -1,271 +1,376 @@
 # -*- coding: utf-8 -*-
 
-# Form implementation generated from reading ui file '/home/etienne/Toolbox/visbrain/visbrain/utils/gui/screenshot_gui.ui'
-#
-# Created by: PyQt5 UI code generator 5.6
-#
-# WARNING! All changes made in this file will be lost!
+################################################################################
+## Form generated from reading UI file 'screenshot_gui.ui'
+##
+## Created by: Qt User Interface Compiler version 6.7.1
+##
+## WARNING! All changes made in this file will be lost when recompiling UI file!
+################################################################################
 
 from visbrain.qt import QtCore, QtGui, QtWidgets
 
+
 class Ui_Screenshot(object):
     def setupUi(self, Screenshot):
-        Screenshot.setObjectName("Screenshot")
+        if not Screenshot.objectName():
+            Screenshot.setObjectName(u"Screenshot")
         Screenshot.resize(341, 563)
         self.verticalLayout_3 = QtWidgets.QVBoxLayout(Screenshot)
-        self.verticalLayout_3.setObjectName("verticalLayout_3")
+        self.verticalLayout_3.setObjectName(u"verticalLayout_3")
         self.gridLayout_5 = QtWidgets.QGridLayout()
-        self.gridLayout_5.setObjectName("gridLayout_5")
+        self.gridLayout_5.setObjectName(u"gridLayout_5")
         self.label = QtWidgets.QLabel(Screenshot)
+        self.label.setObjectName(u"label")
         font = QtGui.QFont()
         font.setItalic(True)
         self.label.setFont(font)
-        self.label.setObjectName("label")
+
         self.gridLayout_5.addWidget(self.label, 0, 0, 1, 1)
+
         self._ssSelect = QtWidgets.QComboBox(Screenshot)
-        self._ssSelect.setObjectName("_ssSelect")
         self._ssSelect.addItem("")
         self._ssSelect.addItem("")
+        self._ssSelect.setObjectName(u"_ssSelect")
+
         self.gridLayout_5.addWidget(self._ssSelect, 0, 2, 1, 1)
+
         self.line = QtWidgets.QFrame(Screenshot)
-        self.line.setFrameShape(QtWidgets.QFrame.VLine)
-        self.line.setFrameShadow(QtWidgets.QFrame.Sunken)
-        self.line.setObjectName("line")
+        self.line.setObjectName(u"line")
+        self.line.setFrameShape(QtWidgets.QFrame.Shape.VLine)
+        self.line.setFrameShadow(QtWidgets.QFrame.Shadow.Sunken)
+
         self.gridLayout_5.addWidget(self.line, 0, 1, 1, 1)
-        spacerItem = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
-        self.gridLayout_5.addItem(spacerItem, 1, 2, 1, 1)
+
+        self.horizontalSpacer_2 = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Minimum)
+
+        self.gridLayout_5.addItem(self.horizontalSpacer_2, 1, 2, 1, 1)
+
+
         self.verticalLayout_3.addLayout(self.gridLayout_5)
+
         self._ssCanvasW = QtWidgets.QWidget(Screenshot)
-        self._ssCanvasW.setObjectName("_ssCanvasW")
+        self._ssCanvasW.setObjectName(u"_ssCanvasW")
         self.verticalLayout_2 = QtWidgets.QVBoxLayout(self._ssCanvasW)
-        self.verticalLayout_2.setContentsMargins(0, 0, 0, 0)
-        self.verticalLayout_2.setObjectName("verticalLayout_2")
+        self.verticalLayout_2.setObjectName(u"verticalLayout_2")
+        self.verticalLayout_2.setContentsMargins(0, -1, 0, -1)
         self.gridLayout_2 = QtWidgets.QGridLayout()
-        self.gridLayout_2.setObjectName("gridLayout_2")
+        self.gridLayout_2.setObjectName(u"gridLayout_2")
         self._ssCustomW = QtWidgets.QWidget(self._ssCanvasW)
-        self._ssCustomW.setObjectName("_ssCustomW")
+        self._ssCustomW.setObjectName(u"_ssCustomW")
         self.verticalLayout = QtWidgets.QVBoxLayout(self._ssCustomW)
-        self.verticalLayout.setContentsMargins(0, 0, 0, 0)
-        self.verticalLayout.setObjectName("verticalLayout")
+        self.verticalLayout.setObjectName(u"verticalLayout")
+        self.verticalLayout.setContentsMargins(0, -1, 0, -1)
         self.gridLayout_3 = QtWidgets.QGridLayout()
-        self.gridLayout_3.setObjectName("gridLayout_3")
+        self.gridLayout_3.setObjectName(u"gridLayout_3")
         self.label_5 = QtWidgets.QLabel(self._ssCustomW)
-        font = QtGui.QFont()
-        font.setItalic(True)
+        self.label_5.setObjectName(u"label_5")
         self.label_5.setFont(font)
-        self.label_5.setObjectName("label_5")
+
         self.gridLayout_3.addWidget(self.label_5, 0, 0, 1, 1)
+
         self.gridLayout = QtWidgets.QGridLayout()
-        self.gridLayout.setObjectName("gridLayout")
+        self.gridLayout.setObjectName(u"gridLayout")
         self._ssWidth = QtWidgets.QDoubleSpinBox(self._ssCustomW)
-        self._ssWidth.setMaximum(10000.0)
-        self._ssWidth.setProperty("value", 10.0)
-        self._ssWidth.setObjectName("_ssWidth")
+        self._ssWidth.setObjectName(u"_ssWidth")
+        self._ssWidth.setMaximum(10000.000000000000000)
+        self._ssWidth.setValue(10.000000000000000)
+
         self.gridLayout.addWidget(self._ssWidth, 0, 1, 1, 1)
+
         self.label_6 = QtWidgets.QLabel(self._ssCustomW)
-        self.label_6.setObjectName("label_6")
+        self.label_6.setObjectName(u"label_6")
+
         self.gridLayout.addWidget(self.label_6, 0, 0, 1, 1)
+
         self.label_7 = QtWidgets.QLabel(self._ssCustomW)
-        self.label_7.setObjectName("label_7")
+        self.label_7.setObjectName(u"label_7")
+
         self.gridLayout.addWidget(self.label_7, 1, 0, 1, 1)
+
         self._ssHeight = QtWidgets.QDoubleSpinBox(self._ssCustomW)
-        self._ssHeight.setMaximum(10000.0)
-        self._ssHeight.setProperty("value", 10.0)
-        self._ssHeight.setObjectName("_ssHeight")
+        self._ssHeight.setObjectName(u"_ssHeight")
+        self._ssHeight.setMaximum(10000.000000000000000)
+        self._ssHeight.setValue(10.000000000000000)
+
         self.gridLayout.addWidget(self._ssHeight, 1, 1, 1, 1)
-        spacerItem1 = QtWidgets.QSpacerItem(40, 0, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
-        self.gridLayout.addItem(spacerItem1, 2, 1, 1, 1)
+
+        self.horizontalSpacer_7 = QtWidgets.QSpacerItem(40, 0, QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Minimum)
+
+        self.gridLayout.addItem(self.horizontalSpacer_7, 2, 1, 1, 1)
+
+
         self.gridLayout_3.addLayout(self.gridLayout, 0, 2, 1, 1)
+
         self.label_3 = QtWidgets.QLabel(self._ssCustomW)
-        font = QtGui.QFont()
-        font.setItalic(True)
+        self.label_3.setObjectName(u"label_3")
         self.label_3.setFont(font)
-        self.label_3.setObjectName("label_3")
+
         self.gridLayout_3.addWidget(self.label_3, 2, 0, 1, 1)
+
         self.line_6 = QtWidgets.QFrame(self._ssCustomW)
-        self.line_6.setFrameShape(QtWidgets.QFrame.VLine)
-        self.line_6.setFrameShadow(QtWidgets.QFrame.Sunken)
-        self.line_6.setObjectName("line_6")
+        self.line_6.setObjectName(u"line_6")
+        self.line_6.setFrameShape(QtWidgets.QFrame.Shape.VLine)
+        self.line_6.setFrameShadow(QtWidgets.QFrame.Shadow.Sunken)
+
         self.gridLayout_3.addWidget(self.line_6, 2, 1, 1, 1)
-        spacerItem2 = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
-        self.gridLayout_3.addItem(spacerItem2, 5, 2, 1, 1)
+
+        self.horizontalSpacer_5 = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Minimum)
+
+        self.gridLayout_3.addItem(self.horizontalSpacer_5, 5, 2, 1, 1)
+
         self._ssBgcolor = QtWidgets.QLineEdit(self._ssCustomW)
+        self._ssBgcolor.setObjectName(u"_ssBgcolor")
         self._ssBgcolor.setEnabled(False)
-        self._ssBgcolor.setObjectName("_ssBgcolor")
+
         self.gridLayout_3.addWidget(self._ssBgcolor, 3, 2, 1, 1)
+
         self._ssUnit = QtWidgets.QComboBox(self._ssCustomW)
-        self._ssUnit.setObjectName("_ssUnit")
         self._ssUnit.addItem("")
         self._ssUnit.addItem("")
         self._ssUnit.addItem("")
         self._ssUnit.addItem("")
+        self._ssUnit.setObjectName(u"_ssUnit")
+
         self.gridLayout_3.addWidget(self._ssUnit, 1, 2, 1, 1)
+
         self._ssDpi = QtWidgets.QSpinBox(self._ssCustomW)
+        self._ssDpi.setObjectName(u"_ssDpi")
         self._ssDpi.setMinimum(100)
         self._ssDpi.setMaximum(600)
-        self._ssDpi.setProperty("value", 300)
-        self._ssDpi.setObjectName("_ssDpi")
+        self._ssDpi.setValue(300)
+
         self.gridLayout_3.addWidget(self._ssDpi, 2, 2, 1, 1)
+
         self.line_5 = QtWidgets.QFrame(self._ssCustomW)
-        self.line_5.setFrameShape(QtWidgets.QFrame.VLine)
-        self.line_5.setFrameShadow(QtWidgets.QFrame.Sunken)
-        self.line_5.setObjectName("line_5")
+        self.line_5.setObjectName(u"line_5")
+        self.line_5.setFrameShape(QtWidgets.QFrame.Shape.VLine)
+        self.line_5.setFrameShadow(QtWidgets.QFrame.Shadow.Sunken)
+
         self.gridLayout_3.addWidget(self.line_5, 1, 1, 1, 1)
+
         self.line_4 = QtWidgets.QFrame(self._ssCustomW)
-        self.line_4.setFrameShape(QtWidgets.QFrame.VLine)
-        self.line_4.setFrameShadow(QtWidgets.QFrame.Sunken)
-        self.line_4.setObjectName("line_4")
+        self.line_4.setObjectName(u"line_4")
+        self.line_4.setFrameShape(QtWidgets.QFrame.Shape.VLine)
+        self.line_4.setFrameShadow(QtWidgets.QFrame.Shadow.Sunken)
+
         self.gridLayout_3.addWidget(self.line_4, 0, 1, 1, 1)
+
         self.line_8 = QtWidgets.QFrame(self._ssCustomW)
-        self.line_8.setFrameShape(QtWidgets.QFrame.VLine)
-        self.line_8.setFrameShadow(QtWidgets.QFrame.Sunken)
-        self.line_8.setObjectName("line_8")
+        self.line_8.setObjectName(u"line_8")
+        self.line_8.setFrameShape(QtWidgets.QFrame.Shape.VLine)
+        self.line_8.setFrameShadow(QtWidgets.QFrame.Shadow.Sunken)
+
         self.gridLayout_3.addWidget(self.line_8, 3, 1, 1, 1)
+
         self.label_4 = QtWidgets.QLabel(self._ssCustomW)
-        font = QtGui.QFont()
-        font.setItalic(True)
+        self.label_4.setObjectName(u"label_4")
         self.label_4.setFont(font)
-        self.label_4.setObjectName("label_4")
+
         self.gridLayout_3.addWidget(self.label_4, 1, 0, 1, 1)
+
         self._ssTransp = QtWidgets.QCheckBox(self._ssCustomW)
-        self._ssTransp.setObjectName("_ssTransp")
+        self._ssTransp.setObjectName(u"_ssTransp")
+
         self.gridLayout_3.addWidget(self._ssTransp, 4, 0, 1, 3)
+
         self._ssBgcolorChk = QtWidgets.QCheckBox(self._ssCustomW)
-        font = QtGui.QFont()
-        font.setItalic(True)
+        self._ssBgcolorChk.setObjectName(u"_ssBgcolorChk")
         self._ssBgcolorChk.setFont(font)
-        self._ssBgcolorChk.setObjectName("_ssBgcolorChk")
+
         self.gridLayout_3.addWidget(self._ssBgcolorChk, 3, 0, 1, 1)
+
+
         self.verticalLayout.addLayout(self.gridLayout_3)
+
+
         self.gridLayout_2.addWidget(self._ssCustomW, 3, 0, 1, 3)
+
         self._ssFactorW = QtWidgets.QWidget(self._ssCanvasW)
-        self._ssFactorW.setObjectName("_ssFactorW")
+        self._ssFactorW.setObjectName(u"_ssFactorW")
         self.verticalLayout_4 = QtWidgets.QVBoxLayout(self._ssFactorW)
-        self.verticalLayout_4.setContentsMargins(0, 0, 0, 0)
-        self.verticalLayout_4.setObjectName("verticalLayout_4")
+        self.verticalLayout_4.setObjectName(u"verticalLayout_4")
+        self.verticalLayout_4.setContentsMargins(0, -1, 0, -1)
         self.gridLayout_4 = QtWidgets.QGridLayout()
-        self.gridLayout_4.setObjectName("gridLayout_4")
-        spacerItem3 = QtWidgets.QSpacerItem(40, 0, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
-        self.gridLayout_4.addItem(spacerItem3, 1, 2, 1, 1)
+        self.gridLayout_4.setObjectName(u"gridLayout_4")
+        self.horizontalSpacer_6 = QtWidgets.QSpacerItem(40, 0, QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Minimum)
+
+        self.gridLayout_4.addItem(self.horizontalSpacer_6, 1, 2, 1, 1)
+
         self.label_9 = QtWidgets.QLabel(self._ssFactorW)
-        font = QtGui.QFont()
-        font.setItalic(True)
+        self.label_9.setObjectName(u"label_9")
         self.label_9.setFont(font)
-        self.label_9.setObjectName("label_9")
+
         self.gridLayout_4.addWidget(self.label_9, 0, 0, 1, 1)
+
         self._ssFactor = QtWidgets.QDoubleSpinBox(self._ssFactorW)
-        self._ssFactor.setMinimum(0.1)
-        self._ssFactor.setMaximum(20.0)
-        self._ssFactor.setProperty("value", 1.0)
-        self._ssFactor.setObjectName("_ssFactor")
+        self._ssFactor.setObjectName(u"_ssFactor")
+        self._ssFactor.setMinimum(0.100000000000000)
+        self._ssFactor.setMaximum(20.000000000000000)
+        self._ssFactor.setValue(1.000000000000000)
+
         self.gridLayout_4.addWidget(self._ssFactor, 0, 2, 1, 1)
+
         self.line_7 = QtWidgets.QFrame(self._ssFactorW)
-        self.line_7.setFrameShape(QtWidgets.QFrame.VLine)
-        self.line_7.setFrameShadow(QtWidgets.QFrame.Sunken)
-        self.line_7.setObjectName("line_7")
+        self.line_7.setObjectName(u"line_7")
+        self.line_7.setFrameShape(QtWidgets.QFrame.Shape.VLine)
+        self.line_7.setFrameShadow(QtWidgets.QFrame.Shadow.Sunken)
+
         self.gridLayout_4.addWidget(self.line_7, 0, 1, 1, 1)
+
+
         self.verticalLayout_4.addLayout(self.gridLayout_4)
+
+
         self.gridLayout_2.addWidget(self._ssFactorW, 4, 0, 1, 3)
+
         self._ssCanvasName = QtWidgets.QComboBox(self._ssCanvasW)
-        self._ssCanvasName.setObjectName("_ssCanvasName")
+        self._ssCanvasName.setObjectName(u"_ssCanvasName")
+
         self.gridLayout_2.addWidget(self._ssCanvasName, 0, 2, 1, 1)
+
         self._ssResolution = QtWidgets.QComboBox(self._ssCanvasW)
-        self._ssResolution.setObjectName("_ssResolution")
         self._ssResolution.addItem("")
         self._ssResolution.addItem("")
+        self._ssResolution.setObjectName(u"_ssResolution")
+
         self.gridLayout_2.addWidget(self._ssResolution, 2, 2, 1, 1)
-        spacerItem4 = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
-        self.gridLayout_2.addItem(spacerItem4, 1, 2, 1, 1)
+
+        self.horizontalSpacer = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Minimum)
+
+        self.gridLayout_2.addItem(self.horizontalSpacer, 1, 2, 1, 1)
+
         self._ssAutocrop = QtWidgets.QCheckBox(self._ssCanvasW)
-        self._ssAutocrop.setObjectName("_ssAutocrop")
+        self._ssAutocrop.setObjectName(u"_ssAutocrop")
+
         self.gridLayout_2.addWidget(self._ssAutocrop, 5, 0, 1, 3)
+
         self.label_8 = QtWidgets.QLabel(self._ssCanvasW)
-        font = QtGui.QFont()
-        font.setItalic(True)
+        self.label_8.setObjectName(u"label_8")
         self.label_8.setFont(font)
-        self.label_8.setObjectName("label_8")
+
         self.gridLayout_2.addWidget(self.label_8, 2, 0, 1, 1)
+
         self.label_2 = QtWidgets.QLabel(self._ssCanvasW)
-        font = QtGui.QFont()
-        font.setItalic(True)
+        self.label_2.setObjectName(u"label_2")
         self.label_2.setFont(font)
-        self.label_2.setObjectName("label_2")
+
         self.gridLayout_2.addWidget(self.label_2, 0, 0, 1, 1)
+
         self.line_2 = QtWidgets.QFrame(self._ssCanvasW)
-        self.line_2.setFrameShape(QtWidgets.QFrame.VLine)
-        self.line_2.setFrameShadow(QtWidgets.QFrame.Sunken)
-        self.line_2.setObjectName("line_2")
+        self.line_2.setObjectName(u"line_2")
+        self.line_2.setFrameShape(QtWidgets.QFrame.Shape.VLine)
+        self.line_2.setFrameShadow(QtWidgets.QFrame.Shadow.Sunken)
+
         self.gridLayout_2.addWidget(self.line_2, 0, 1, 1, 1)
+
         self.line_3 = QtWidgets.QFrame(self._ssCanvasW)
-        self.line_3.setFrameShape(QtWidgets.QFrame.VLine)
-        self.line_3.setFrameShadow(QtWidgets.QFrame.Sunken)
-        self.line_3.setObjectName("line_3")
+        self.line_3.setObjectName(u"line_3")
+        self.line_3.setFrameShape(QtWidgets.QFrame.Shape.VLine)
+        self.line_3.setFrameShadow(QtWidgets.QFrame.Shadow.Sunken)
+
         self.gridLayout_2.addWidget(self.line_3, 2, 1, 1, 1)
+
+
         self.verticalLayout_2.addLayout(self.gridLayout_2)
+
+
         self.verticalLayout_3.addWidget(self._ssCanvasW)
+
         self.horizontalLayout_2 = QtWidgets.QHBoxLayout()
-        self.horizontalLayout_2.setObjectName("horizontalLayout_2")
-        spacerItem5 = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
-        self.horizontalLayout_2.addItem(spacerItem5)
+        self.horizontalLayout_2.setObjectName(u"horizontalLayout_2")
+        self.horizontalSpacer_3 = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Minimum)
+
+        self.horizontalLayout_2.addItem(self.horizontalSpacer_3)
+
         self._ssRun = QtWidgets.QPushButton(Screenshot)
-        self._ssRun.setObjectName("_ssRun")
+        self._ssRun.setObjectName(u"_ssRun")
+
         self.horizontalLayout_2.addWidget(self._ssRun)
-        spacerItem6 = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
-        self.horizontalLayout_2.addItem(spacerItem6)
+
+        self.horizontalSpacer_4 = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Minimum)
+
+        self.horizontalLayout_2.addItem(self.horizontalSpacer_4)
+
+
         self.verticalLayout_3.addLayout(self.horizontalLayout_2)
-        spacerItem7 = QtWidgets.QSpacerItem(20, 40, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding)
-        self.verticalLayout_3.addItem(spacerItem7)
+
+        self.verticalSpacer = QtWidgets.QSpacerItem(20, 40, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Expanding)
+
+        self.verticalLayout_3.addItem(self.verticalSpacer)
+
 
         self.retranslateUi(Screenshot)
+
         QtCore.QMetaObject.connectSlotsByName(Screenshot)
+    # setupUi
 
     def retranslateUi(self, Screenshot):
-        _translate = QtCore.QCoreApplication.translate
-        Screenshot.setWindowTitle(_translate("Screenshot", "Form"))
-        self.label.setText(_translate("Screenshot", "Render"))
-        self._ssSelect.setToolTip(_translate("Screenshot", "<html><head/><body><p>Render either :</p><p>- The entire window</p><p>- One selected canvas</p></body></html>"))
-        self._ssSelect.setItemText(0, _translate("Screenshot", "Selected canvas"))
-        self._ssSelect.setItemText(1, _translate("Screenshot", "Entire window"))
-        self.label_5.setText(_translate("Screenshot", "Size"))
-        self._ssWidth.setToolTip(_translate("Screenshot", "<html><head/><body><p>Width (in centimeter, millimeter, pixel or inch) of rendered image at the dpi level</p></body></html>"))
-        self.label_6.setText(_translate("Screenshot", "Width"))
-        self.label_7.setText(_translate("Screenshot", "Height"))
-        self._ssHeight.setToolTip(_translate("Screenshot", "<html><head/><body><p>Height (in centimeter, millimeter, pixel or inch) of rendered image at the dpi level</p></body></html>"))
-        self.label_3.setText(_translate("Screenshot", "dpi"))
-        self._ssBgcolor.setToolTip(_translate("Screenshot", "<html><head/><body><p>Use either the name of the color (e.g. black, white...), a RGB tuple (e.g. (0., 1., 0.)...) or an hexadecimal string (e.g. #ab4642)</p></body></html>"))
-        self._ssBgcolor.setPlaceholderText(_translate("Screenshot", "black, (.1, .1, .1), #ab4642..."))
-        self._ssUnit.setToolTip(_translate("Screenshot", "<html><head/><body><p>Size unit</p></body></html>"))
-        self._ssUnit.setItemText(0, _translate("Screenshot", "centimeter"))
-        self._ssUnit.setItemText(1, _translate("Screenshot", "millimeter"))
-        self._ssUnit.setItemText(2, _translate("Screenshot", "pixel"))
-        self._ssUnit.setItemText(3, _translate("Screenshot", "inch"))
-        self._ssDpi.setToolTip(_translate("Screenshot", "<html><head/><body><p>dpi level for the rendered image</p></body></html>"))
-        self.label_4.setText(_translate("Screenshot", "Unit"))
-        self._ssTransp.setToolTip(_translate("Screenshot", "<html><head/><body><p>Force to have a transparent background</p></body></html>"))
-        self._ssTransp.setText(_translate("Screenshot", "Use transparent background"))
-        self._ssBgcolorChk.setToolTip(_translate("Screenshot", "<html><head/><body><p><span style=\" font-style:normal;\">Change the background color.</span></p></body></html>"))
-        self._ssBgcolorChk.setText(_translate("Screenshot", "Background\n"
-"color"))
-        self.label_9.setText(_translate("Screenshot", "Factor"))
-        self._ssFactor.setToolTip(_translate("Screenshot", "<html><head/><body><p>Multiply the original canvas size by this factor. For instance, if the canvas has a size of (1020, 800) and factor is 2. then the rendered image will have a size of (2040, 1600)</p></body></html>"))
-        self._ssCanvasName.setToolTip(_translate("Screenshot", "<html><head/><body><p>Choose the canvas to render</p></body></html>"))
-        self._ssResolution.setToolTip(_translate("Screenshot", "<html><head/><body><p>Change the image resolution for rendering :</p><p>- <span style=\" font-weight:600;\">Custom  :</span> specify the image size (controlled by unit) at a specific dpi level. Note that the rendering might not have the exact desired size but will try instead to conserve the proportion width/height</p><p>- <span style=\" font-weight:600;\">Proportional :</span> increase the size of the image proportionaly to the original canvas size.</p></body></html>"))
-        self._ssResolution.setItemText(0, _translate("Screenshot", "Custom image size"))
-        self._ssResolution.setItemText(1, _translate("Screenshot", "Proportional to screen size"))
-        self._ssAutocrop.setToolTip(_translate("Screenshot", "<html><head/><body><p>Automatically crop the image to non-background values</p></body></html>"))
-        self._ssAutocrop.setText(_translate("Screenshot", "autocrop"))
-        self.label_8.setText(_translate("Screenshot", "Image resolution"))
-        self.label_2.setText(_translate("Screenshot", "Canvas name"))
-        self._ssRun.setToolTip(_translate("Screenshot", "<html><head/><body><p>Run the screenshot</p></body></html>"))
-        self._ssRun.setText(_translate("Screenshot", "Run"))
+        Screenshot.setWindowTitle(QtCore.QCoreApplication.translate("Screenshot", u"Screenshot", None))
+        self.label.setText(QtCore.QCoreApplication.translate("Screenshot", u"Render", None))
+        self._ssSelect.setItemText(0, QtCore.QCoreApplication.translate("Screenshot", u"Selected canvas", None))
+        self._ssSelect.setItemText(1, QtCore.QCoreApplication.translate("Screenshot", u"Entire window", None))
 
+#if QT_CONFIG(tooltip)
+        self._ssSelect.setToolTip(QtCore.QCoreApplication.translate("Screenshot", u"<html><head/><body><p>Render either :</p><p>- The entire window</p><p>- One selected canvas</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+        self.label_5.setText(QtCore.QCoreApplication.translate("Screenshot", u"Size", None))
+#if QT_CONFIG(tooltip)
+        self._ssWidth.setToolTip(QtCore.QCoreApplication.translate("Screenshot", u"<html><head/><body><p>Width (in centimeter, millimeter, pixel or inch) of rendered image at the dpi level</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+        self.label_6.setText(QtCore.QCoreApplication.translate("Screenshot", u"Width", None))
+        self.label_7.setText(QtCore.QCoreApplication.translate("Screenshot", u"Height", None))
+#if QT_CONFIG(tooltip)
+        self._ssHeight.setToolTip(QtCore.QCoreApplication.translate("Screenshot", u"<html><head/><body><p>Height (in centimeter, millimeter, pixel or inch) of rendered image at the dpi level</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+        self.label_3.setText(QtCore.QCoreApplication.translate("Screenshot", u"dpi", None))
+#if QT_CONFIG(tooltip)
+        self._ssBgcolor.setToolTip(QtCore.QCoreApplication.translate("Screenshot", u"<html><head/><body><p>Use either the name of the color (e.g. black, white...), a RGB tuple (e.g. (0., 1., 0.)...) or an hexadecimal string (e.g. #ab4642)</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+        self._ssBgcolor.setPlaceholderText(QtCore.QCoreApplication.translate("Screenshot", u"black, (.1, .1, .1), #ab4642...", None))
+        self._ssUnit.setItemText(0, QtCore.QCoreApplication.translate("Screenshot", u"centimeter", None))
+        self._ssUnit.setItemText(1, QtCore.QCoreApplication.translate("Screenshot", u"millimeter", None))
+        self._ssUnit.setItemText(2, QtCore.QCoreApplication.translate("Screenshot", u"pixel", None))
+        self._ssUnit.setItemText(3, QtCore.QCoreApplication.translate("Screenshot", u"inch", None))
 
-if __name__ == "__main__":
-    import sys
-    app = QtWidgets.QApplication(sys.argv)
-    Screenshot = QtWidgets.QWidget()
-    ui = Ui_Screenshot()
-    ui.setupUi(Screenshot)
-    Screenshot.show()
-    sys.exit(app.exec_())
+#if QT_CONFIG(tooltip)
+        self._ssUnit.setToolTip(QtCore.QCoreApplication.translate("Screenshot", u"<html><head/><body><p>Size unit</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+#if QT_CONFIG(tooltip)
+        self._ssDpi.setToolTip(QtCore.QCoreApplication.translate("Screenshot", u"<html><head/><body><p>dpi level for the rendered image</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+        self.label_4.setText(QtCore.QCoreApplication.translate("Screenshot", u"Unit", None))
+#if QT_CONFIG(tooltip)
+        self._ssTransp.setToolTip(QtCore.QCoreApplication.translate("Screenshot", u"<html><head/><body><p>Force to have a transparent background</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+        self._ssTransp.setText(QtCore.QCoreApplication.translate("Screenshot", u"Use transparent background", None))
+#if QT_CONFIG(tooltip)
+        self._ssBgcolorChk.setToolTip(QtCore.QCoreApplication.translate("Screenshot", u"<html><head/><body><p><span style=\" font-style:normal;\">Change the background color.</span></p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+        self._ssBgcolorChk.setText(QtCore.QCoreApplication.translate("Screenshot", u"Background\n"
+"color", None))
+        self.label_9.setText(QtCore.QCoreApplication.translate("Screenshot", u"Factor", None))
+#if QT_CONFIG(tooltip)
+        self._ssFactor.setToolTip(QtCore.QCoreApplication.translate("Screenshot", u"<html><head/><body><p>Multiply the original canvas size by this factor. For instance, if the canvas has a size of (1020, 800) and factor is 2. then the rendered image will have a size of (2040, 1600)</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+#if QT_CONFIG(tooltip)
+        self._ssCanvasName.setToolTip(QtCore.QCoreApplication.translate("Screenshot", u"<html><head/><body><p>Choose the canvas to render</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+        self._ssResolution.setItemText(0, QtCore.QCoreApplication.translate("Screenshot", u"Custom image size", None))
+        self._ssResolution.setItemText(1, QtCore.QCoreApplication.translate("Screenshot", u"Proportional to screen size", None))
+
+#if QT_CONFIG(tooltip)
+        self._ssResolution.setToolTip(QtCore.QCoreApplication.translate("Screenshot", u"<html><head/><body><p>Change the image resolution for rendering :</p><p>- <span style=\" font-weight:600;\">Custom  :</span> specify the image size (controlled by unit) at a specific dpi level. Note that the rendering might not have the exact desired size but will try instead to conserve the proportion width/height</p><p>- <span style=\" font-weight:600;\">Proportional :</span> increase the size of the image proportionaly to the original canvas size.</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+#if QT_CONFIG(tooltip)
+        self._ssAutocrop.setToolTip(QtCore.QCoreApplication.translate("Screenshot", u"<html><head/><body><p>Automatically crop the image to non-background values</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+        self._ssAutocrop.setText(QtCore.QCoreApplication.translate("Screenshot", u"autocrop", None))
+        self.label_8.setText(QtCore.QCoreApplication.translate("Screenshot", u"Image resolution", None))
+        self.label_2.setText(QtCore.QCoreApplication.translate("Screenshot", u"Canvas name", None))
+#if QT_CONFIG(tooltip)
+        self._ssRun.setToolTip(QtCore.QCoreApplication.translate("Screenshot", u"<html><head/><body><p>Run the screenshot</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+        self._ssRun.setText(QtCore.QCoreApplication.translate("Screenshot", u"Run", None))
+    # retranslateUi
 

--- a/visbrain/utils/gui/screenshot_gui.ui
+++ b/visbrain/utils/gui/screenshot_gui.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string>Screenshot</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>

--- a/visbrain/visuals/cbar/gui/CbarPyQtGui.py
+++ b/visbrain/visuals/cbar/gui/CbarPyQtGui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'CbarPyQtGui.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.2
+## Created by: Qt User Interface Compiler version 6.7.1
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################


### PR DESCRIPTION
## Summary
- retitle the screenshot dialog UI while checking it with Qt 6 tooling
- extend the Qt UI regeneration helper to cover visbrain/utils/gui modules
- regenerate screenshot_gui.py (and dependent headers) with pyside6-uic using visbrain.qt imports

## Testing
- make flake
- pytest visbrain/utils/tests/test_guitools.py
- pytest visbrain/gui/signal/tests/test_signal.py *(fails: aborts while instantiating the Signal GUI in a headless environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d17d87a9d48328ad581065962719e0